### PR TITLE
fix: userSchema null age lockout + dev setup (docker project + admin seed)

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,8 +1,12 @@
+# Nombre de proyecto propio para NO colisionar con otros repos que tengan
+# una carpeta 'backend' (p.ej. RUKLO). Aisla red, volumenes y contenedores.
+name: vigilia
+
 services:
   # Base de datos PostgreSQL (único servicio mantenido)
   postgres:
     image: postgres:15-alpine
-    container_name: postgres_db
+    container_name: vigilia_postgres
     env_file:
       - ./.env
     environment:

--- a/backend/scripts/seed-admin.js
+++ b/backend/scripts/seed-admin.js
@@ -1,0 +1,92 @@
+/**
+ * Seed de usuario Super Administrador para desarrollo.
+ *
+ * Uso:
+ *   node scripts/seed-admin.js <email> <password> [nombre] [rut] [phone]
+ *
+ * Idempotente: si el email ya existe, actualiza password + confirmed y
+ * asegura el rol Super Administrador. Lee la config de DB desde backend/.env.
+ * Usa el mismo hashing que el backend (bcrypt, 10 rounds).
+ */
+const fs = require('fs');
+const path = require('path');
+const bcrypt = require('bcrypt');
+const { Client } = require('pg');
+
+// --- parse .env (simple key=value) ---
+function loadEnv() {
+  const envPath = path.resolve(__dirname, '..', '.env');
+  const env = {};
+  for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/i);
+    if (m) env[m[1]] = m[2].replace(/^['"]|['"]$/g, '');
+  }
+  return env;
+}
+
+async function main() {
+  const [email, password, name = 'Administrador', rut = '11111111-1', phone = '+56999999999', ageArg = '30'] = process.argv.slice(2);
+  const age = parseInt(ageArg, 10) || 30; // el frontend exige age numerico (no null), igual que RegisterDto
+  if (!email || !password) {
+    console.error('Uso: node scripts/seed-admin.js <email> <password> [nombre] [rut] [phone]');
+    process.exit(1);
+  }
+
+  const env = loadEnv();
+  const client = new Client({
+    host: env.DB_HOST || 'localhost',
+    port: Number(env.DB_PORT || 5432),
+    user: env.DB_USER,
+    password: env.DB_PASSWORD,
+    database: env.DB_NAME,
+  });
+  await client.connect();
+
+  try {
+    const emailLc = email.toLowerCase();
+    const hash = await bcrypt.hash(password, 10);
+
+    // rol Super Administrador
+    const roleRes = await client.query(
+      `SELECT id FROM role WHERE name ILIKE '%Super Admin%' LIMIT 1`,
+    );
+    if (roleRes.rowCount === 0) throw new Error('No existe el rol Super Administrador (¿corriste el backend para sembrar roles?)');
+    const roleId = roleRes.rows[0].id;
+
+    // upsert user por email
+    const existing = await client.query(`SELECT id FROM "user" WHERE email = $1`, [emailLc]);
+    let userId;
+    if (existing.rowCount > 0) {
+      userId = existing.rows[0].id;
+      await client.query(
+        `UPDATE "user" SET password = $1, confirmed = true, name = $2, "updatedAt" = now() WHERE id = $3`,
+        [hash, name, userId],
+      );
+      console.log(`Usuario existente actualizado: ${emailLc} (${userId})`);
+    } else {
+      const ins = await client.query(
+        `INSERT INTO "user" (rut, name, email, phone, password, confirmed, age)
+         VALUES ($1, $2, $3, $4, $5, true, $6) RETURNING id`,
+        [rut, name, emailLc, phone, hash, age],
+      );
+      userId = ins.rows[0].id;
+      console.log(`Usuario creado: ${emailLc} (${userId})`);
+    }
+
+    // asegurar rol (idempotente)
+    await client.query(
+      `INSERT INTO user_roles_role ("userId", "roleId") VALUES ($1, $2)
+       ON CONFLICT ("userId", "roleId") DO NOTHING`,
+      [userId, roleId],
+    );
+
+    console.log(`Rol Super Administrador asignado. Listo para login: ${emailLc}`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((e) => {
+  console.error('Error en seed-admin:', e.message);
+  process.exit(1);
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -103,7 +103,7 @@ export const userSchema = z.object({
     email: z.string().email(),
     phone: z.string().max(15),
     password: z.string().optional(), // Opcional porque no siempre se incluye en las respuestas
-    age: z.number().int().positive().optional(),
+    age: z.number().int().positive().nullable().optional(),
     profilePicture: z.string().nullable().optional(),
     confirmed: z.boolean().default(false),
     createdAt: z.string().transform((date) => new Date(date)),


### PR DESCRIPTION
## Cambios

### `fix(frontend)` — 403 por age=null
Un usuario con `age = null` (columna nullable) hacía fallar `userSchema.safeParse` en `getUser`, dejando al frontend **sin usuario ni permisos → 403 en toda ruta protegida** (muy difícil de diagnosticar). Fix: `age` pasa a `.nullable().optional()` en `frontend/src/types/index.ts`.

### `chore(dev)` — setup local
- **docker-compose**: `name: vigilia` top-level para que el proyecto Docker no colisione con otros repos que tengan carpeta `backend/` (mismo namespace de compose → recreaba contenedores ajenos).
- **scripts/seed-admin.js**: bootstrap idempotente del primer Super Admin (el endpoint de registro está deshabilitado por diseño, así que el primer admin no se puede crear por API).

## Notas
- No incluye cambios de `package-lock.json` (solo era normalización de npm).
- Pendiente aparte (ya conocido): gap de auth en endpoints de ingesta LPR/anomalías.