### PR TITLE
docs: plan de mejora inicial (visión, arquitectura objetivo, fases, decisiones)

### DIFF
--- a/docs/01-vision-contexto.md
+++ b/docs/01-vision-contexto.md
@@ -1,0 +1,33 @@
+# 01 — Visión y contexto
+
+## Identificación
+- **Título:** Conserje Digital Inteligente para Condominios mediante Visión Computacional e integración IoT.
+- **Autores:** Amin Carrizo y Benjamin Muñoz. **Profesor guía:** Mauricio Oyarzun.
+- **Tipo de tesis:** Emprendimiento (el sistema debe ser **reutilizable y vendible** a distintos condominios).
+- **Piloto:** Condominio San Lorenzo (Región de Tarapacá — Iquique / Alto Hospicio).
+
+## El problema
+Muchos condominios de la región no tienen conserje ni portero, y la seguridad se limita a un sistema de cámaras y un portón, **sin monitoreo activo ni registro de visitas**. El control de acceso depende de la buena voluntad de los vecinos. Esto genera vacíos de gestión y riesgos de intrusión. El caso San Lorenzo es exactamente este.
+
+## La solución: un agente conserje autónomo
+No es "un sistema con LPR + citófono". Es **un agente de IA (el "conserje digital") que actúa como el cerebro del condominio**, y todo lo demás (cámaras, citófono, app) son sus **sentidos y manos**. El agente:
+- Atiende las llamadas del citófono (habla con el visitante).
+- Registra y gestiona visitas.
+- Redirige la llamada a la casa correcta y coordina la autorización con el residente.
+- Abre portón/puerta cuando corresponde.
+- Razona sobre anomalías, accesos y eventos, y toma acciones.
+
+Se apoya en la infraestructura **análoga/pasiva existente** (cámaras y citófono GT) mediante un dispositivo IoT de bajo costo (Raspberry) que la digitaliza.
+
+## Objetivos de la tesis (criterios de evaluación)
+1. Visión computacional: reconocimiento automático de **patentes** y, opcionalmente, **rostros**, con las cámaras existentes.
+2. Dispositivo **IoT de bajo costo** para adaptar el citófono tradicional → apertura de portón + comunicación digital.
+3. App **web/móvil** para residentes: registrar vehículos, programar visitas, notificaciones, autorizar accesos en tiempo real.
+4. **Dashboard administrativo**: registro de accesos, reportes de visitas, gestión centralizada.
+5. **Validar en piloto** con métricas: precisión de reconocimiento, tiempos de respuesta, satisfacción de usuarios.
+
+## El diferenciador comercial
+El LPR de patentes es *commodity*. Lo vendible y novedoso es **el agente conserje autónomo**: que atiende, decide, registra y coordina la seguridad de forma continua. Toda la inversión de aquí en adelante debe reforzar esa narrativa.
+
+## Modelo de negocio 🔴 (pendiente)
+Aún no definido. Dependerá del split **cloud vs edge** (qué corre en la nube y qué en el sitio, especialmente los modelos de IA que procesan las cámaras). Posibles ejes de cobro: por condominio, por casa, por cámara. Ver [05-decisiones-tecnicas.md](05-decisiones-tecnicas.md#d5).

--- a/docs/02-estado-actual.md
+++ b/docs/02-estado-actual.md
@@ -1,0 +1,40 @@
+# 02 — Estado actual del sistema
+
+Foto del monorepo a **julio 2026** (tras retomar el proyecto).
+
+## Subsistemas
+
+| Carpeta | Stack | Rol | Estado |
+|---|---|---|---|
+| `backend/` | NestJS 11 + TypeORM/PostgreSQL | API central: auth/RBAC, vehículos, visitas (QR), cámaras/MediaMTX, notificaciones, ingesta de detecciones, digital-concierge | Maduro/funcional |
+| `frontend/` | React 18 + Vite + TanStack Query + Tailwind v4 | App admin/residente/conserje: LPR, streaming (WHEP), trazabilidad, anomalías, dashboard | Maduro |
+| `lpr/` | Python + FastAPI + YOLOv11 + fast-plate-ocr | Reconocimiento de patentes (worker por cámara) + modo "guardia" (anomalías) | Funcional, foco IA |
+| `vigilia-hub/` | Node/TS (Raspberry Pi) | Puente físico del citófono GT: GPIO, relés, DTMF, audio, apertura de portón | Funcional (prototipo) |
+| `mediamtx/` | Binario | Servidor de medios RTSP/WebRTC para las cámaras del condominio | Infra |
+| `rtsp-simple-server/` | Binario (= mediamtx) | Solo para **simular** la webcam local como RTSP en pruebas | Redundante con mediamtx |
+
+## Flujo estrella: control de acceso por patente
+Cámara → `lpr/` (YOLO detecta patente → OCR → confirma) → `POST /detections/plates` → `DetectionsService.createDetection()` cruza contra vehículos/visitas → decide **Permitido/Denegado** → si Permitido dispara `hub:door_open` (abre portón físico vía `vigilia-hub`) → si no hay match, va a **aprobación del conserje** (expira 5 min).
+
+## El conserje digital HOY (hallazgo importante)
+La lógica del agente de voz ("Sofía") está **duplicada en dos clientes**:
+- **Frontend** (`DigitalConciergeView.tsx`) — SDK `@openai/agents/realtime` (WebRTC).
+- **vigilia-hub** (`concierge-client.service.ts`) — WebSocket nativo a OpenAI ("réplica exacta del flujo del frontend").
+
+Cada copia tiene **su propio prompt y sus propias tools**, y **ya divergieron** (drift). El **backend no orquesta el diálogo**: solo genera el token efímero de OpenAI y ejecuta 4 tools cuando el cliente se las pide (`guardar_datos_visitante`, `buscar_residente`, `notificar_residente`, `reenviar_notificacion`).
+
+➡️ **El cerebro vive en los clientes (por duplicado); el backend es solo un ejecutor de manos.** Es lo que hay que invertir (ver [03](03-arquitectura-objetivo.md)).
+
+Lo que sí está del lado servidor y sirve de base: `DigitalConciergeService` integra Users/Families/Visits/Notifications/Hub/SMS/QR; el dispatcher `executeTool(toolName)` es el enganche natural; `ConciergeSession` ya tiene `source: 'web'|'hub'` y `hubId`; `HubGateway` es el canal seguro backend→Raspberry.
+
+## Gaps / deuda conocida
+- 🔴 **Seguridad:** endpoints de ingesta (`/detections/plates`, `/anomalies`) y el de token de OpenAI (`/concierge/session/start`) **sin auth**. Una detección "Permitido" abre el portón → cualquiera con la URL podría abrirlo o abusar del token de IA. Existe `createServiceToken()` sin enganchar.
+- 🔴 **Multi-tenant:** una sola DB (`developDB`, un condominio). Para SaaS multi-condominio falta aislamiento por tenant.
+- 🟡 **Tests:** cobertura casi nula en módulos críticos (detections, concierge, worker LPR).
+- 🟡 **Modelos de visión** relativamente antiguos (YOLOv11 + fast-plate-ocr); conviene evaluar los últimos.
+- 🟡 **Duplicación del agente** (frontend vs hub) → doble mantenimiento y comportamiento inconsistente.
+- 🔴 **Sistema de cámaras del condominio SIN confirmar** (probablemente Hikvision/RTSP). No bloqueante por ahora.
+- `TypeORM synchronize: true` en backend (deuda ya reconocida en el código).
+
+## Infra local (desarrollo)
+Backend `:3000` (API en `/api/v1`), frontend Vite `:5173`, Postgres `:5455` (proyecto Docker aislado `vigilia`), MediaMTX (RTSP `:8554`, WebRTC `:8889`). El worker LPR (Python) y `vigilia-hub` (Raspberry) se levantan aparte. Detalle en la memoria de sesión "como-levantar-el-stack".

--- a/docs/03-arquitectura-objetivo.md
+++ b/docs/03-arquitectura-objetivo.md
@@ -1,0 +1,60 @@
+# 03 — Arquitectura objetivo
+
+## Principio rector
+**El backend es el único dueño del cerebro del agente** (prompt + definición de tools + orquestación del diálogo y del function-calling). El web y el hub pasan a ser **transportes delgados** (capturan y reproducen audio, muestran estado), sin lógica de agente. Una sola fuente de verdad, sin duplicación.
+
+El agente no solo conversa: es **event-driven**. Reacciona a eventos (llegó una patente, sonó el citófono, hay una anomalía, un residente pidió algo) y decide acciones usando sus tools.
+
+## Las 4 capas
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  CEREBRO (cloud, backend NestJS)                                       │
+│  Agente: prompt único + tools + orquestación + function-calling        │
+│  Razona sobre eventos y decide acciones. Provider-agnóstico.           │
+└───────────┬───────────────────────────────────────┬──────────────────┘
+            │ tools = wrappers de los módulos        │ eventos entran
+            ▼                                        ▼
+┌──────────────────────────┐        ┌───────────────────────────────────┐
+│  MANOS (módulos backend) │        │  EVENTOS                          │
+│  visitas, vehículos,     │        │  detección de patente, anomalía,  │
+│  residentes, portón,     │        │  llamada de citófono, petición    │
+│  notificaciones, reportes│        │  de residente                     │
+└──────────────────────────┘        └───────────────────────────────────┘
+            ▲                                        ▲
+            │ HubGateway (WS seguro)                 │
+┌───────────┴────────────────────────┐   ┌───────────┴──────────────────┐
+│  TRANSPORTE DE VOZ                  │   │  VISIÓN (edge o cloud)        │
+│  - web: monitorear/intervenir      │   │  lpr/ : YOLO + OCR (patentes) │
+│  - vigilia-hub: audio real del     │   │  + anomalías. Corre cerca de  │
+│    citófono GT                      │   │  las cámaras, emite EVENTOS.  │
+└─────────────────────────────────────┘   └──────────────────────────────┘
+```
+
+## El rol de `vigilia-hub` (dispositivo de punteo del citófono GT)
+Es un dispositivo IoT que va **dentro** del sistema de citófono **Aiphone GT** e **intercepta la llamada antes de que llegue a la casa del residente**. Puentea:
+- **Micrófono, altavoz y teclado** del citófono.
+- **Decodifica las señales R1 y R2** del GT (para saber qué casa marcó el visitante e inyectar señales).
+
+Con eso, el agente (en el backend) puede: atender la llamada, hablar con el visitante, **redirigir la llamada a la casa que el visitante marcó originalmente**, abrir portón/puerta, o cortar. El hub es el **transporte de audio + actuador físico**; la decisión la toma el cerebro en el backend, que le habla al hub por `HubGateway`.
+
+> Nota: el manual `GT_System` (Aiphone) es de este citófono, NO de las cámaras.
+
+## Cerebro vs transporte de voz
+Separar dos cosas que hoy están mezcladas:
+- **Cerebro / razonamiento + tools** → framework de agente provider-agnóstico en el backend (candidato: Vercel AI SDK + AI Gateway — ver [D1](05-decisiones-tecnicas.md#d1)).
+- **Voz en tiempo real** (speech-to-speech de baja latencia con el visitante) → capa de transporte, posiblemente un modelo realtime dedicado. Decisión abierta ([D2](05-decisiones-tecnicas.md#d2)).
+
+## Cloud vs Edge (eje central del SaaS)
+Decisión que define el modelo de negocio ([D5](05-decisiones-tecnicas.md#d5)):
+- **Cloud:** el cerebro (agente), la DB, la app web, el dashboard, la orquestación multi-condominio.
+- **Edge (en el condominio):** el `vigilia-hub` (obligatorio, está en el hardware) y **probablemente la inferencia de visión** (LPR/anomalías) corriendo cerca de las cámaras, para no subir video crudo a la nube (ancho de banda, latencia, privacidad) y enviar solo **eventos**. El `lpr/` ya está diseñado como worker por-cámara, lo que encaja con edge.
+
+## Multi-tenant (SaaS) — base fundacional
+Para "vendible a varios condominios" se necesita **aislamiento por tenant** (condominio) en datos, auth y configuración. **Decidido** ([D4](05-decisiones-tecnicas.md#d4)): migrar a **better-auth** y hacerlo **Fase 0**, para que el agente-cerebro y todos los módulos nazcan **tenant-aware** en vez de retrofitear el aislamiento después. Se hace ahora que no hay datos que migrar.
+
+## Qué se conserva del sistema actual
+- `DigitalConciergeService` y su dispatcher `executeTool` → base del set de tools del agente.
+- `HubGateway` → canal cerebro→hub para acciones físicas.
+- `ConciergeSession(source, hubId)` → ya modela el origen multi-canal.
+- Módulos de dominio (visitas, vehículos, notificaciones, detecciones) → se exponen como tools.

--- a/docs/04-plan-por-fases.md
+++ b/docs/04-plan-por-fases.md
@@ -1,0 +1,60 @@
+# 04 — Plan de mejora por fases
+
+Plan priorizado para llevar el prototipo a un sistema **robusto, production-ready y comercializable**. El orden pone primero la base (auth + multi-tenant), para que todo lo que se construya encima nazca aislado por condominio.
+
+> Estado: 🔴 no iniciado · 🟡 en progreso · 🟢 hecho. Todas las fases están 🔴 salvo lo indicado.
+
+## Horizonte temporal
+- **Tope:** noviembre. **Ideal:** mediados de septiembre. Son fechas **holgadas** (colchón), no un cronograma inflado.
+- **Cadencia real:** desarrollo asistido por IA (Claude Code) → se avanza en **días por fase, no semanas**. Medir por **entregable**, no por calendario.
+- **Orden:** Fase 0 (auth/multi-tenant) → Fases 1–2 (agente-cerebro, el diferenciador) → Fases 3–4 (visión, métricas, hardening).
+- Regla: no sobredimensionar; la Fase 0 es plumbing con librería, debe ser rápida.
+
+## Fase 0 — Auth robusta + Multi-tenant (migración a better-auth) 🔴 *fundacional*
+Cerrar identidad, sesiones y aislamiento por condominio de una, aprovechando que hoy no hay datos que migrar.
+- **POC primero** (de-risk, ver [D4](05-decisiones-tecnicas.md#d4)): integración better-auth + NestJS, y mapeo del RBAC fino (79 permisos) al modelo de organization/access-control.
+- Migrar auth a **better-auth** (identidad, sesiones, OAuth/2FA si aplica, plugins de organización/multi-tenant).
+- Modelo de **tenant = condominio**: aislamiento en datos (scoping por `tenantId`), auth y configuración.
+- Cerrar el **gap de auth en endpoints** hoy abiertos (ingesta LPR/anomalías + token de OpenAI).
+- **Entregable:** auth robusta + sistema multi-tenant listo; todo lo siguiente se construye tenant-aware.
+- *Habilita la tesis de emprendimiento (SaaS multi-condominio) + "production-ready".*
+
+## Fase 1 — Consolidar el agente-cerebro en el backend 🔴
+Matar la duplicación y mover el cerebro al servidor, ya tenant-aware.
+- Cerebro (prompt + tools + orquestación) como **única fuente de verdad en el backend**.
+- Web y `vigilia-hub` pasan a **transportes delgados** (audio/estado, sin lógica de agente).
+- Separar responsabilidades (`OpenAITokenService` mezcla voz + Vision).
+- **Entregable:** el agente responde y actúa desde el backend; los clientes solo transportan.
+
+## Fase 2 — Agente-cerebro completo 🔴
+El agente como gestor con acceso a todas las capacidades.
+- Framework de agente provider-agnóstico ([D1](05-decisiones-tecnicas.md#d1) — Vercel AI SDK + `@ai-sdk/gateway`).
+- **Set completo de tools** sobre los módulos: vehículos, visitas, portón/puerta, llamar a residencia, anomalías/accesos, reportes, notificaciones.
+- Orquestación **event-driven** (patente, citófono, anomalía → decisión).
+- Capa de **voz en tiempo real** ([D2](05-decisiones-tecnicas.md#d2)): RPi como puente delgado, voz en la nube.
+- **Entregable:** un agente que atiende el citófono y razona/actúa sobre el sistema. **← corazón del diferenciador.**
+
+## Fase 3 — Visión: evaluación y mejora 🔴
+- Evaluar la **última YOLO** (variante nano) vs los modelos actuales, para patentes, OCR y anomalías, con benchmark sobre datos del piloto ([D3](05-decisiones-tecnicas.md#d3)).
+- Definir el split **cloud/edge** de inferencia con números reales ([D5](05-decisiones-tecnicas.md#d5)).
+- (Opcional, objetivo 1) reconocimiento de **rostros**.
+- **Entregable:** pipeline de visión validado con números + costo por condominio.
+
+## Fase 4 — Métricas, validación en piloto y hardening 🔴
+- **Métricas al dashboard** para admins del condominio + métricas internas de desarrollo.
+- Validación en piloto (objetivo 5): precisión, tiempos de respuesta, satisfacción.
+- **Tests** en módulos críticos, observabilidad, quitar `synchronize:true`.
+- **Entregable:** evidencia cuantitativa para la defensa + sistema desplegable.
+
+## Mapa fases ↔ objetivos de la tesis
+| Objetivo | Fase(s) |
+|---|---|
+| 1. Visión (patentes/rostros) | 3 (base en el sistema actual) |
+| 2. IoT citófono | 1–2 (agente + hub como transporte) |
+| 3. App residentes | ya construida; se refina transversalmente |
+| 4. Dashboard admin | 4 (métricas) |
+| 5. Validación con métricas | 4 |
+| SaaS multi-condominio (emprendimiento) | 0 |
+
+## Fases y módulos
+Las fases se ejecutan por **módulos**; al abrir un módulo se documenta su diseño en `docs/modulos/<modulo>.md` antes de implementar. Este archivo es el índice de alto nivel.

--- a/docs/05-decisiones-tecnicas.md
+++ b/docs/05-decisiones-tecnicas.md
@@ -68,6 +68,11 @@ Decisiones abiertas y en discusión. Formato mini-ADR. Estado: 🟢 decidido · 
 
 **Riesgo asumido:** re-homar los flujos actuales (register/confirm/forgot/reset/profile/service-token/email) al modelo de better-auth. Bounded, y más barato ahora que con datos.
 
+**Resultado del research (jul-2026) — camino elegido:**
+- **Stack:** lib community `@thallesp/nestjs-better-auth` (v2.7.0, activa) **+** las skills de skills.sh (agent-skills, se usan junto con la lib). NO montar el handler vanilla.
+- **Enfoque híbrido (confirmado por el mapa de auth):** better-auth para identidad/sesión/**organización (=condominio)**/roles gruesos; el **RBAC fino (79 permisos) queda app-side intacto** (`AuthorizationGuard` + `@RequirePermissions`, 114 usos, no se tocan). Poblar permisos en la sesión con `customSession`.
+- **Diseño + plan completo:** ver [modulos/auth-multitenant.md](modulos/auth-multitenant.md). Decisiones abiertas ahí: modelo User (A vs C), sesión (cookies vs stateless), service-token, teams.
+
 ---
 
 ## D5 — Cloud vs Edge (define el modelo de negocio) 🟡

--- a/docs/05-decisiones-tecnicas.md
+++ b/docs/05-decisiones-tecnicas.md
@@ -1,0 +1,94 @@
+# 05 — Decisiones técnicas
+
+Decisiones abiertas y en discusión. Formato mini-ADR. Estado: 🟢 decidido · 🟡 en discusión · 🔴 pendiente.
+
+---
+
+## D1 — Framework del agente (cerebro) 🟡
+**Contexto:** hoy el agente está atado a OpenAI y duplicado en clientes. Se quiere un cerebro en el backend, provider-agnóstico.
+
+**Propuesta de Benjamin:** [Vercel AI SDK](https://ai-sdk.dev/) + AI Gateway.
+
+**Evaluación (Nova):** buena elección y apropiada.
+- ✅ Provider-agnóstico (OpenAI, Anthropic, Google, etc.), tool-calling de primera clase, streaming, TypeScript-nativo → encaja directo en el backend NestJS.
+- ✅ El AI Gateway agrega ruteo/fallback/observabilidad de proveedores, pero **es opcional**: el desacople de proveedor ya lo da el SDK a nivel de código (puedes usar los providers directo sin Gateway). Ojo: el Gateway es un servicio hosteado (dependencia + costo + los datos pasan por Vercel) — a considerar si algo debe ser on-prem/edge.
+- 💡 **Alternativa a evaluar encima del AI SDK:** [Mastra](https://mastra.ai/) — framework de agentes construido sobre el propio Vercel AI SDK; añade agentes, workflows, memory y tools con más estructura. Si queremos scaffolding de agente listo, Mastra; si queremos control total y mínimas dependencias, AI SDK "core" (`streamText`/`generateText` + tools + loop propio).
+
+**Lean:** AI SDK core como base; evaluar Mastra si necesitamos más andamiaje. Gateway opcional.
+
+---
+
+## D2 — Capa de voz en tiempo real 🟡
+**Contexto:** el cerebro (D1) razona con texto/tools; hablar con el visitante en el citófono necesita **speech-to-speech de baja latencia**. Son problemas distintos.
+
+**Opciones:**
+- (a) Mantener un **modelo realtime dedicado** (hoy OpenAI Realtime) como transporte de voz, y que sus tool-calls apunten al **cerebro del backend** (única fuente de verdad de tools/lógica).
+- (b) Desacoplar STT → cerebro (AI SDK, cualquier modelo) → TTS: 100% provider-agnóstico pero **más latencia** (malo para una llamada).
+
+**Lean:** (a) — voz realtime como transporte, tools resueltas por el backend. Reconcilia "cerebro agnóstico" con "mejor voz". Revisar si el AI SDK/Gateway ya expone una vía realtime aceptable.
+
+**Voz en la Raspberry (decidido 🟢):** la RPi NO corre ASR. Es un **puente de audio delgado** (captura mic del citófono + reproduce respuesta); el speech-to-speech ocurre en la nube (modelo realtime). Lo único local: **VAD** liviano (`webrtcvad` / Silero) para turnos. Excepción: si no hay internet confiable en la conserjería, STT offline con **Vosk** (mejor que whisper.cpp en RPi, tiene español) — degrada UX, no es el default del piloto.
+
+> Nota: "AI Gateway" = el provider `@ai-sdk/gateway` del propio AI SDK (acceso multi-modelo + failover con una API key), no un producto edge aparte. Los datos pasan por el gateway hosteado (a considerar solo si algo debe ser 100% on-prem).
+
+---
+
+## D3 — Modelos de visión 🟡
+**Contexto:** hoy YOLOv11 + fast-plate-ocr (relativamente antiguos), para patentes, OCR y anomalías.
+
+**Propuesta de Benjamin:** evaluar la última YOLO (variante nano) para detección de patentes, extracción de texto y anomalías/seguridad.
+
+**Evaluación (Nova):**
+- 👍 Buena idea evaluar, pero **medir, no cambiar a ciegas**. La versión exacta ("v26") hay que **verificar cuál es la vigente** de Ultralytics antes de comprometerla.
+- El **detector** (YOLO) y el **OCR de patentes** son dos modelos distintos: mejorar uno no mejora el otro. El texto de la patente depende tanto o más del OCR.
+- Para anomalías hay una segunda etapa (GPT-4o Vision). Evaluar si conviene un detector edge + verificación en la nube.
+
+**Acción:** armar un **harness de benchmark** con patentes reales/etiquetadas del piloto y comparar objetivamente (precisión, latencia, tamaño) los candidatos. Se puede delegar una investigación del SOTA actual (deep-web-researcher) cuando lleguemos a Fase 3.
+
+---
+
+## D4 — Auth + Multi-tenant 🟢 (decidido: migrar a better-auth, es Fase 0)
+**Contexto:** hoy JWT + RBAC propio (roles/permisos/service-token), **funcional**. Se quiere multi-tenant para SaaS.
+
+**Propuesta de Benjamin:** migrar a [better-auth](https://www.better-auth.com/) (tiene plugins de organización/multi-tenant).
+
+**Evaluación (Nova) — cuidado, trade-off real:**
+- La **multi-tenancy es un problema de la capa de datos**, resoluble SIN cambiar de librería de auth (agregar `tenantId` a las entidades + guard/interceptor de scoping por tenant). Bajo riesgo, lo controlas tú.
+- Migrar auth es un **rewrite significativo**: re-implementar el RBAC que ya funciona, y **verificar que better-auth encaje bien con NestJS** (better-auth está más orientado a Next.js/Hono; su fit con Nest no es de primera clase — a validar antes de comprometer).
+- Better-auth sí vale la pena **si además** quieres sus otras features (OAuth social, orgs, 2FA, sesiones robustas), no solo por el multi-tenant.
+
+**DECISIÓN (Benjamin, 2026-07-11):** migrar a **better-auth** y hacerlo **Fase 0 (fundacional)** para cerrar identidad robusta + multi-tenant desde el inicio, de modo que el agente-cerebro nazca tenant-aware. Aprovechar que **hoy hay ~cero datos (1 usuario)** → la migración es lo más barata que va a ser nunca.
+
+**Razonamiento a favor:** mantener auth hecho a mano es un pasivo (sensible; ya tiene huecos: register deshabilitado, service-token sin enganchar, endpoints sin guard); better-auth trae identidad/sesiones/OAuth/2FA/organizaciones battle-tested; y multi-tenant es central a la tesis de emprendimiento.
+
+**Guardias antes de comprometer la migración completa (POC/spike primero):**
+1. **Fit con NestJS** — el core de better-auth es agnóstico (se monta su handler en una ruta), pero no es un módulo Nest nativo; validar que quede cableado limpio.
+2. **Mapeo del RBAC fino (79 permisos)** — ver si el plugin organization/access-control lo modela, o dejar permisos app-side y usar better-auth solo para identidad/sesiones/orgs.
+3. **Timebox** — es plumbing con librería; no debe comerse el runway de septiembre (donde vive el agente). Si amenaza, se recorta alcance.
+
+**Riesgo asumido:** re-homar los flujos actuales (register/confirm/forgot/reset/profile/service-token/email) al modelo de better-auth. Bounded, y más barato ahora que con datos.
+
+---
+
+## D5 — Cloud vs Edge (define el modelo de negocio) 🟡
+**Contexto:** ¿qué corre en la nube y qué en el sitio? Clave por los modelos de IA que procesan cámaras.
+
+**Evaluación (Nova):**
+- **Edge (en el condominio):** el `vigilia-hub` (obligado, está en el hardware) y **la inferencia de visión** (LPR/anomalías) cerca de las cámaras → NO subir video crudo a la nube (ancho de banda, latencia, privacidad), enviar solo **eventos**. El `lpr/` ya es worker por-cámara → encaja. Requiere un **equipo edge** con cómputo (mini-PC / Jetson; la RPi sola es lenta para YOLO).
+- **Cloud:** cerebro (agente), DB, app web, dashboard, orquestación multi-condominio.
+- **Modelo de negocio derivado:** suscripción SaaS por condominio (cloud) + **appliance edge** (venta/arriendo del equipo). Limpio y defendible.
+
+**Restricción de presupuesto:** NO hay plata para Jetson/mini-PC. El edge debe caber en una **Raspberry Pi 5** o irse a la nube donde salga más barato. Análisis:
+- **LPR en RPi5: plausible por-evento** (no 24/7): motion-trigger en el portón → YOLO **nano optimizado** (NCNN/ONNX) a pocos FPS → OCR. Un auto en el portón es lento, no se necesitan 30 FPS.
+- **Anomalías/seguridad: NO continuo en RPi** (modelo más pesado + ya se usa GPT-4o Vision). Hacerlo **cloud-on-trigger** (solo frames gatillados).
+- **Regla de oro:** el edge manda **eventos/frames**, NUNCA video crudo continuo a la nube (eso dispara ancho de banda + GPU 24/7 y mata el margen del SaaS).
+- **Modelo de negocio derivado:** SaaS por condominio (cloud) + la RPi5 como appliance edge barato (puente citófono + LPR gatillado).
+
+**Lean:** edge (RPi5) para hub + LPR gatillado; cloud para cerebro/datos/app + Vision-on-trigger. **Pendiente:** números reales (FPS de YOLO nano en RPi5, costo de inferencia cloud, inversión por condominio) → investigar con deep-web-researcher.
+
+---
+
+## D6 — Sistema de cámaras del condominio 🔴 (pendiente, no bloqueante)
+**Lo que se sabe:** San Lorenzo tiene cámaras Hikvision visibles desde una app móvil. Benjamin vive ahí pero no ha podido acceder a la conserjería (no hay contacto con el conserje estos días).
+**Riesgo/hipótesis:** alta probabilidad de que sean **IP con RTSP nativo** (Hikvision: `rtsp://user:pass@ip:554/Streaming/Channels/101`) → premisa viable sin encoder.
+**Falta confirmar:** ¿hay NVR? IPs/credenciales, cobertura del portón. **No bloquea** el trabajo de arquitectura/agente; sí bloquea la prueba real de captura.

--- a/docs/06-bitacora.md
+++ b/docs/06-bitacora.md
@@ -4,6 +4,13 @@ Registro cronológico de conversaciones, decisiones y avances. Lo más reciente 
 
 ---
 
+## 2026-07-11 (cont. 3) — Research better-auth + mapa de auth → diseño Fase 0
+- **Research (deep-web-researcher, jul-2026):** la lib `@thallesp/nestjs-better-auth` está sana (v2.7.0, 4-jul-2026); las skills de skills.sh son agent-skills que se usan junto con la lib. Recomendación: lib community + skills, NO vanilla. Organization plugin = tenant; RBAC fino mejor app-side (customSession). CVEs parchadas en jun-2026 → pinnear versión.
+- **Mapa de auth (codebase-explorer):** hallazgo clave = el RBAC es SEPARABLE de la autenticación (`AuthorizationGuard` solo lee `request.user`), así que se reemplaza solo la capa de sesión y se conservan los 114 usos de `@RequirePermissions`. Blast radius acotado.
+- **Entregable:** [modulos/auth-multitenant.md](modulos/auth-multitenant.md) — diseño + plan de migración de la Fase 0, con 4 decisiones abiertas para Benjamin (modelo User, sesión, service-token, teams).
+
+---
+
 ## 2026-07-11 (cont. 2) — better-auth pasa a ser Fase 0
 - **Decisión:** migrar a **better-auth** como **Fase 0 (fundacional)** para cerrar auth robusta + multi-tenant desde el inicio, y que el agente-cerebro nazca tenant-aware. Se aprovecha que hoy hay ~cero datos (migración barata).
 - **Guardia de tech lead:** POC primero (fit NestJS + mapeo de los 79 permisos) y **timebox**, para no comerse el runway de septiembre (donde vive el agente, el diferenciador).

--- a/docs/06-bitacora.md
+++ b/docs/06-bitacora.md
@@ -1,0 +1,48 @@
+# 06 — Bitácora
+
+Registro cronológico de conversaciones, decisiones y avances. Lo más reciente arriba.
+
+---
+
+## 2026-07-11 (cont. 2) — better-auth pasa a ser Fase 0
+- **Decisión:** migrar a **better-auth** como **Fase 0 (fundacional)** para cerrar auth robusta + multi-tenant desde el inicio, y que el agente-cerebro nazca tenant-aware. Se aprovecha que hoy hay ~cero datos (migración barata).
+- **Guardia de tech lead:** POC primero (fit NestJS + mapeo de los 79 permisos) y **timebox**, para no comerse el runway de septiembre (donde vive el agente, el diferenciador).
+- El plan se reordenó: Fase 0 = auth/multi-tenant; Fase 1 = consolidar agente-cerebro en backend; Fase 2 = agente completo; Fase 3 = visión; Fase 4 = métricas/piloto/hardening. Ver [04](04-plan-por-fases.md).
+
+---
+
+## 2026-07-11 (cont.) — Decisiones técnicas afinadas
+- **Timeline:** ideal "todo perfecto" a mediados de septiembre (~2 meses); tope noviembre (5 meses). → meta sept = agente-cerebro (Fases 0–1); resto a nov.
+- **Voz en RPi (🟢):** la Raspberry es puente de audio delgado; el speech-to-speech va en la nube (realtime). VAD liviano local. Vosk solo si no hay internet.
+- **AI Gateway:** aclarado que es el provider `@ai-sdk/gateway` del AI SDK.
+- **better-auth (revisado):** se aprueba avanzar (buena opción para SaaS + hoy no hay datos = migración barata), condicionado a un POC (fit NestJS + mapeo RBAC).
+- **Presupuesto edge:** sin plata para Jetson → el edge cabe en RPi5 (LPR gatillado por evento) o va a la nube (Vision-on-trigger). Regla: el edge manda eventos/frames, nunca video continuo. Falta investigar números concretos (FPS RPi5, costo cloud).
+- **Hardware:** Benjamin decodifica las señales R1/R2 del citófono GT hoy.
+- Amin no participa en la construcción.
+
+---
+
+## 2026-07-11 — Retoma del proyecto + definición de enfoque y futuro
+
+**Contexto:** Benjamin retoma la tesis tras un tiempo sin tocarla (antes trabajada con GitHub Copilot, primera vez con Claude Code).
+
+**Trabajo técnico de la sesión:**
+- Se indexó el monorepo con **CodeGraph** (índices por-subproyecto + índice raíz unificado + auto-sync) y se actualizó CodeGraph a v1.4.1.
+- Se exploró y entendió toda la arquitectura (backend, frontend, lpr, vigilia-hub).
+- Se **rescató trabajo sin commitear** (feature "Guardián Visual" end-to-end + LogsModule que estaba mal ignorado por gitignore) y se consolidó en `main` vía PRs #45/#46. Ramas viejas limpiadas; repo quedó ordenado (solo `main`).
+- Se levantó el stack completo en local (backend, frontend, Postgres, MediaMTX) y se verificó funcionando. Se aisló el proyecto Docker como `vigilia` (chocaba con RUKLO por carpetas `backend/` homónimas; data de RUKLO intacta).
+- Se sembró un usuario Super Admin de bootstrap y se corrigió un bug real (`userSchema.age` no aceptaba `null` → 403 en toda ruta protegida).
+
+**Conversación estratégica (lo importante):**
+- Se aclaró la **visión**: el proyecto es un **agente conserje autónomo** (el cerebro del condominio), no "LPR + citófono". Ver [01](01-vision-contexto.md).
+- **Hallazgo clave:** el agente de voz hoy vive **duplicado** en frontend y `vigilia-hub`, ya divergido; el backend solo mintea tokens y ejecuta 4 tools. Ver [02](02-estado-actual.md).
+- **Decisión de rumbo:** mover el **cerebro al backend** como única fuente de verdad; web y hub pasan a transportes delgados. Ver [03](03-arquitectura-objetivo.md).
+- Se detalló el rol de `vigilia-hub`: dispositivo de punteo **dentro** del citófono **Aiphone GT**, que intercepta la llamada antes de la casa, puentea mic/altavoz/teclado, decodifica R1/R2, redirige a la casa marcada, abre portón/puerta.
+- Se definió el **plan por fases** ([04](04-plan-por-fases.md)) y se abrieron **decisiones técnicas** ([05](05-decisiones-tecnicas.md)): Vercel AI SDK (+Gateway) para el agente, capa de voz realtime, evaluar última YOLO, better-auth vs extender RBAC para multi-tenant, split cloud/edge, cámaras pendientes.
+
+**Aclaraciones de Benjamin:**
+- Cámaras: quedan como incógnita por ahora (sin contacto con el conserje), no bloqueante, alta probabilidad RTSP/Hikvision.
+- Amin no participa en la construcción; Benjamin lleva solo el desarrollo (avisará si delega).
+- Modelo de negocio aún abierto, depende del split cloud/edge.
+
+**Próximo paso sugerido:** iniciar Fase 0 por un módulo concreto (consolidar el cerebro del agente en el backend), documentando el diseño del módulo antes de implementar.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# Documentación — Vigilia / Conserje Digital Inteligente
+
+Carpeta de documentación viva del proyecto de título **"Conserje Digital Inteligente para Condominios mediante Visión Computacional e integración IoT"**.
+
+Su objetivo es dejar registrado el **enfoque, la arquitectura, el plan por fases y las decisiones técnicas**, para guiar el desarrollo y servir de material para la tesis (y para compartir con el profesor guía).
+
+## Índice
+
+| Doc | Qué contiene |
+|-----|--------------|
+| [01-vision-contexto.md](01-vision-contexto.md) | La idea, el problema, los objetivos de la tesis, el piloto y el diferenciador comercial |
+| [02-estado-actual.md](02-estado-actual.md) | Cómo está construido hoy el monorepo, qué funciona y los hallazgos/gaps |
+| [03-arquitectura-objetivo.md](03-arquitectura-objetivo.md) | La arquitectura destino: el agente-cerebro en el backend, las capas y el split cloud/edge |
+| [04-plan-por-fases.md](04-plan-por-fases.md) | Plan de mejora priorizado en fases, con entregables y criterios |
+| [05-decisiones-tecnicas.md](05-decisiones-tecnicas.md) | Decisiones abiertas (framework del agente, visión, auth/multi-tenant, cloud vs edge, cámaras) |
+| [06-bitacora.md](06-bitacora.md) | Registro cronológico de conversaciones y decisiones |
+
+## Cómo usar esta carpeta
+
+- Es **documentación viva**: se actualiza a medida que decidimos cosas. Cada decisión cerrada se refleja en `05-decisiones-tecnicas.md` y se anota en `06-bitacora.md`.
+- Estado de cada ítem: 🟢 decidido · 🟡 en discusión · 🔴 pendiente/bloqueado.
+- Autor principal: Benjamin Muñoz. Profesor guía: Mauricio Oyarzun. Piloto: Condominio San Lorenzo.

--- a/docs/modulos/auth-multitenant.md
+++ b/docs/modulos/auth-multitenant.md
@@ -76,11 +76,13 @@ better-auth default = **cookies httpOnly + server session** (lookup en DB). Es m
 - **Express vs Fastify:** el backend debe correr sobre **Express** (el soporte Fastify de la lib es beta, issue `#147`). Confirmar (NestJS default es Express — OK).
 - **Bus-factor** de la lib community → mantener la opción de caer al handler vanilla si se abandonara.
 
-## 10. Decisiones abiertas (necesitan tu OK)
-1. **Modelo User:** ¿opción C (canónica better-auth + extendida, recomendada) o A (identidad separada)?
-2. **Sesión:** ¿cookies httpOnly (recomendado) o stateless JWT?
-3. **Service token del worker LPR:** ¿plugin `apiKey` de better-auth o emisor propio acotado?
-4. ¿Modelamos **torres/edificios** como `team` desde ya, o solo `organization`=condominio por ahora?
+## 10. Decisiones (cerradas — Benjamin, 2026-07-11)
+1. **Modelo User:** ✅ **Opción C** — `user` de better-auth canónica + campos de dominio extendidos (rut/phone/age/family/roles). Un solo modelo de usuario.
+2. **Sesión:** ✅ **Cookies httpOnly** (default de better-auth). El frontend migra de `localStorage.AUTH_TOKEN` a cookies (`withCredentials`).
+3. **Service token (worker LPR):** ✅ **Plugin `apiKey`** de better-auth para credenciales de máquina.
+4. **Tenant:** ✅ **Solo `organization` = condominio** por ahora; `teams` (torres/edificios) se agregan después si el piloto lo pide.
+
+Con esto el diseño queda **cerrado** y listo para implementar en la Fase 0.
 
 ## Fuentes
 Ver informe completo en la bitácora / memoria del research (`agent-memory/deep-web-researcher/better-auth-nestjs-migration-2026.md`). Docs oficiales: better-auth.com (NestJS integration, Organization, Admin, Database, Auth0 migration, Security update June 2026), repo `ThallesP/nestjs-better-auth`, skills.sh/better-auth.

--- a/docs/modulos/auth-multitenant.md
+++ b/docs/modulos/auth-multitenant.md
@@ -1,0 +1,86 @@
+# Fase 0 — Auth robusta + Multi-tenant (better-auth): diseño y plan de migración
+
+> Estado: 🟡 en diseño (para revisar antes de implementar). Basado en research de julio 2026 + mapa del auth actual.
+
+## 1. Objetivo
+Reemplazar el auth JWT+RBAC hecho a mano por una base **robusta y multi-tenant** para el SaaS, aprovechando que hoy hay ~cero datos (migración barata). Que el agente-cerebro y todos los módulos nazcan **tenant-aware**.
+
+## 2. Decisión de stack (fundamentada)
+- **Librería:** `@thallesp/nestjs-better-auth` (community, **v2.7.0 · 4-jul-2026**, 569★, activa, peer dep `better-auth >= 1.5.0`). Provee `AuthGuard` global, `@AllowAnonymous()`, `@Roles()`, `@OrgRoles()`, `@UserHasPermission()`, `@MemberHasPermission()` — idiomático NestJS.
+- **NO montar el handler vanilla a mano:** reimplementaríamos justo lo que la lib ya da.
+- **Skills:** instalar `npx skills add better-auth/skills` — son **agent-skills** (guías de mejores prácticas para asistentes de IA como Claude Code), agnósticas de framework. Se usan **junto** con la lib, no en su lugar.
+- **better-auth core:** fijar versión (última estable 1.6.x) y suscribirse a advisories (ver Riesgos).
+- **Riesgo a vigilar:** bus-factor (un mantenedor principal en la lib community).
+
+## 3. Arquitectura: qué maneja cada capa
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ better-auth (identidad + sesión + organización)             │
+│  - user / session / account / verification                  │
+│  - email+password (hash bcrypt override), OAuth, 2FA        │
+│  - organization plugin  →  tenant = CONDOMINIO              │
+│  - roles GRUESOS (6): Super Admin, Admin, Conserje, ...      │
+└───────────────┬─────────────────────────────────────────────┘
+                │ request.user poblado con roles + permisos
+                ▼
+┌─────────────────────────────────────────────────────────────┐
+│ RBAC FINO (app-side, SE MANTIENE INTACTO)                   │
+│  - tabla Permission (79) + AuthorizationGuard               │
+│  - @RequirePermissions / @RequireRoles  (114 usos, 17 files)│
+│  - NO se remapea a better-auth → migración acotada          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Clave (del mapa de auth):** `AuthorizationGuard` solo lee `request.user.roles/permissions`; no le importa quién emitió la sesión. Reemplazamos **solo la capa de identidad/sesión** y conservamos todo el RBAC fino. Para poblar los permisos en la sesión sin round-trip extra por request, usar el plugin **`customSession`** (inyecta `roles`/`permissions` en la respuesta de sesión) o `definePayload` del plugin JWT.
+
+## 4. Reconciliación del modelo `User` (decisión importante 🟡)
+Hoy el `User` es rico (rut, phone, age, family, roles M:N) y **5+ módulos** dependen de `UsersService` (digital-concierge, detections, visits, vehicles, notifications). better-auth "quiere ser dueño" de su tabla `user`. Opciones:
+
+- **A) Identidad separada + perfil app:** better-auth maneja su `user`/`session` mínimos; la app mantiene su `User` rico, enlazados por id. Bajo riesgo, pero **dos conceptos de usuario** que reconciliar (deuda).
+- **B) Mapear better-auth sobre la tabla `User` existente** (`modelName`/`fields`). Riesgo: bugs abiertos `#6391` (override de `account.modelName` en login) y `#3774` (tabla "user" hardcodeada) — verificar antes.
+- **C) ✅ (recomendada) `user` de better-auth como canónica + campos extendidos:** adoptar su `user` como fuente de verdad y colgar los campos de dominio (rut/phone/age/family) y el M:N de roles. Requiere re-homar `UsersService`, pero **hoy no hay datos** y con desarrollo asistido es de días. Deja UN solo modelo de usuario (lo correcto para un SaaS).
+
+**Lean:** C, con A como fallback si los bugs de `modelName` (B) o el re-homing resultan más caros de lo esperado.
+
+## 5. Sesiones
+better-auth default = **cookies httpOnly + server session** (lookup en DB). Es más seguro que el JWT en `localStorage` actual (elimina XSS-token-theft). Cambia el contrato del frontend: `axios.ts`/`useAuth.ts`/`AuthAPI.ts` dejan `localStorage.AUTH_TOKEN` y pasan a cookies (withCredentials). Si se quiere stateless, hay `cookieCache` con `strategy:"jwt"` + plugin JWT (con el trade-off de invalidación).
+**Lean:** cookies httpOnly (default) — más robusto y es lo esperado en un SaaS.
+
+## 6. Casos especiales a resolver
+- **Service token** (`createServiceToken`, JWT largo para el worker LPR): better-auth no lo cubre nativo. → usar el **plugin `apiKey`** o el plugin JWT de better-auth para credenciales de máquina, o mantener un emisor de service-tokens propio acotado. Decidir.
+- **Códigos de 6 dígitos** (confirm/reset, tabla `Token`): se solapan con la verificación nativa de better-auth (`verification`). → migrar esos flujos a better-auth (emailOTP / verification) y retirar la tabla `Token` propia.
+- **Emails** (`AuthEmailService`, 4 flujos): re-cablear a los hooks de better-auth (`sendVerificationEmail`, `sendResetPassword`, etc.) manteniendo tus templates.
+- **bcrypt:** better-auth usa scrypt; override `emailAndPassword.password.hash/verify` para seguir con bcrypt (no hay passwords que migrar igual). 
+- **JWT_SECRET hardcodeado** `'yourSecretKey'` (auth.module.ts:25): arreglar de paso.
+
+## 7. Multi-tenant (organization = condominio)
+- `organization` plugin: tablas `organization`/`member`/`invitation`/`team`; la sesión gana `activeOrganizationId`. → **organization = condominio**.
+- `team` = subgrupo dentro del tenant (útil para **torres/edificios** de un condominio).
+- **Tenant scoping en datos:** agregar `organizationId` a las entidades de dominio (vehículos, visitas, detecciones, cámaras, notificaciones, hubs) + un interceptor/guard que filtre por el tenant activo. Es el grueso del trabajo de aislamiento.
+- `dynamicAccessControl` solo si cada condominio necesitara roles propios en runtime (por ahora, no).
+
+## 8. Plan de migración (por pasos, cadencia en días)
+1. **Spike/POC:** instalar `nestjs-better-auth` + skills; levantar auth email+password con bcrypt override; verificar body-parser deshabilitado y coexistencia con TypeORM (schema separado o tabla compartida).
+2. **Modelo User:** implementar opción C (o A si el POC lo pide); enlazar roles/permisos; poblar `request.user` con permisos (customSession).
+3. **Guards:** cambiar `AuthGuard` propio por el de la lib; **conservar `AuthorizationGuard` + decoradores** (verificar que `request.user` trae `roles.permissions`).
+4. **Flujos:** migrar confirm/reset/forgot a verification de better-auth; re-cablear emails; resolver service-token.
+5. **Multi-tenant:** organization plugin; agregar `organizationId` + scoping a entidades de dominio.
+6. **Frontend:** migrar de `localStorage` a cookies (withCredentials); ajustar `useAuth`/`usePermissions`/`ProtectedRoute` al nuevo contrato.
+7. **Limpieza:** retirar `auth.service`/`auth.guard`/`Token` propios ya reemplazados; arreglar `JWT_SECRET`; tests de los flujos críticos.
+
+## 9. Riesgos y mitigaciones
+- **Seguridad de la propia lib:** el update "Security update: June 2026" parchó varias CVEs (2 críticas en SSO y OIDC/MCP). → **pinnear versión**, no usar plugins deprecados, suscribirse a advisories.
+- **Bugs `modelName`** (`#6391`/`#3774`): afectan la opción B → preferir C.
+- **"better-auth quiere ser dueño del user"** + cookie-chunking (reportes 2026) → diseñar bien el esquema de sesión/cookies; opción C lo evita.
+- **Express vs Fastify:** el backend debe correr sobre **Express** (el soporte Fastify de la lib es beta, issue `#147`). Confirmar (NestJS default es Express — OK).
+- **Bus-factor** de la lib community → mantener la opción de caer al handler vanilla si se abandonara.
+
+## 10. Decisiones abiertas (necesitan tu OK)
+1. **Modelo User:** ¿opción C (canónica better-auth + extendida, recomendada) o A (identidad separada)?
+2. **Sesión:** ¿cookies httpOnly (recomendado) o stateless JWT?
+3. **Service token del worker LPR:** ¿plugin `apiKey` de better-auth o emisor propio acotado?
+4. ¿Modelamos **torres/edificios** como `team` desde ya, o solo `organization`=condominio por ahora?
+
+## Fuentes
+Ver informe completo en la bitácora / memoria del research (`agent-memory/deep-web-researcher/better-auth-nestjs-migration-2026.md`). Docs oficiales: better-auth.com (NestJS integration, Organization, Admin, Database, Auth0 migration, Security update June 2026), repo `ThallesP/nestjs-better-auth`, skills.sh/better-auth.


### PR DESCRIPTION
Documentación viva del proyecto en `docs/`:

- **01 Visión/contexto** — la tesis (Conserje Digital), objetivos, piloto San Lorenzo, diferenciador.
- **02 Estado actual** — arquitectura del monorepo + hallazgos (agente duplicado frontend/hub, gaps de auth/tests/multi-tenant).
- **03 Arquitectura objetivo** — el agente-cerebro en el backend, capas, rol del vigilia-hub (puente citófono GT), cloud/edge.
- **04 Plan por fases** — Fase 0 = auth/multi-tenant (better-auth) · Fase 1–2 = agente-cerebro · Fase 3 = visión · Fase 4 = métricas/hardening.
- **05 Decisiones técnicas** — D1 AI SDK, D2 voz (RPi puente + nube), D3 YOLO, D4 better-auth (decidido), D5 cloud/edge, D6 cámaras.
- **06 Bitácora** — registro de decisiones.

Solo documentación, no toca código.