### PR TITLE
fix(visits): aislamiento tenant del modulo Visits (leak de datos)

### DIFF
--- a/backend/src/detections/detections.service.ts
+++ b/backend/src/detections/detections.service.ts
@@ -91,24 +91,32 @@ export class DetectionsService {
       } else if (vehicle.vehicleType === 'visitante' || vehicle.accessLevel === 'temporal') {
         // Vehículo de visitante, verificar si tiene visita válida
         try {
-          const visitValidation = await this.visitsService.validateAccess(dto.plate, 'plate');
-          
+          // Tarea de aislamiento tenant (branch fix/visits-tenant-isolation):
+          // este endpoint lo llama el worker LPR sin sesión de usuario
+          // (ServiceApiKeyGuard, no puebla request.user) — TenantContextService
+          // no puede resolver el condominio del caller. `skipTenantScope`
+          // preserva el comportamiento resource-derived existente (igual que
+          // resolveCameraOrganizationId arriba): la patente ya es el criterio
+          // de búsqueda, no hace falta acotar por tenant para no romper el
+          // flujo de apertura automática.
+          const visitValidation = await this.visitsService.validateAccess(dto.plate, 'plate', { skipTenantScope: true });
+
           if (visitValidation.valid && visitValidation.visit) {
             const visit = visitValidation.visit;
             decision = 'Permitido';
             residente = visit.host; // El anfitrión es el residente
-            
+
             // Determinar si es entrada o salida basado en el estado de la visita
             if (visit.status === 'pending' || visit.status === 'ready') {
               // Entrada: Visita pendiente o lista para reingreso → registrar check-in
-              await this.visitsService.checkIn(visit.id);
-              reason = visit.status === 'pending' 
+              await this.visitsService.checkIn(visit.id, { skipTenantScope: true });
+              reason = visit.status === 'pending'
                 ? `Entrada autorizada - ${visit.visitorName}`
                 : `Reingreso autorizado - ${visit.visitorName}`;
               isExit = false;
             } else if (visit.status === 'active') {
               // Salida: Visita activa → registrar check-out
-              await this.visitsService.checkOut(visit.id);
+              await this.visitsService.checkOut(visit.id, { skipTenantScope: true });
               reason = `Salida registrada - ${visit.visitorName}`;
               isExit = true;
             } else {
@@ -134,24 +142,26 @@ export class DetectionsService {
     } else if (!vehicle) {
       // No existe el vehículo, verificar si hay una visita programada
       try {
-        const visitValidation = await this.visitsService.validateAccess(dto.plate, 'plate');
-        
+        // Ver comentario equivalente más arriba: worker LPR sin sesión de
+        // usuario, bypass explícito del scoping por tenant.
+        const visitValidation = await this.visitsService.validateAccess(dto.plate, 'plate', { skipTenantScope: true });
+
         if (visitValidation.valid && visitValidation.visit) {
           const visit = visitValidation.visit;
           decision = 'Permitido';
           residente = visit.host;
-          
+
           // Determinar si es entrada o salida basado en el estado de la visita
           if (visit.status === 'pending' || visit.status === 'ready') {
             // Entrada: Visita pendiente o lista para reingreso → registrar check-in
-            await this.visitsService.checkIn(visit.id);
+            await this.visitsService.checkIn(visit.id, { skipTenantScope: true });
             reason = visit.status === 'pending'
               ? `Entrada autorizada - ${visit.visitorName}`
               : `Reingreso autorizado - ${visit.visitorName}`;
             isExit = false;
           } else if (visit.status === 'active') {
             // Salida: Visita activa → registrar check-out
-            await this.visitsService.checkOut(visit.id);
+            await this.visitsService.checkOut(visit.id, { skipTenantScope: true });
             reason = `Salida registrada - ${visit.visitorName}`;
             isExit = true;
           } else {

--- a/backend/src/digital-concierge/services/digital-concierge.service.ts
+++ b/backend/src/digital-concierge/services/digital-concierge.service.ts
@@ -287,7 +287,14 @@ export class DigitalConciergeService {
     try {
       if (approved) {
         // Si se aprueba, registrar entrada (checkIn) para incrementar usedCount correctamente
-        await this.visitsService.checkIn(session.createdVisit.id);
+        // Tarea de aislamiento tenant (branch fix/visits-tenant-isolation): este
+        // flujo (Conserje Digital) no tiene sesión de usuario en absoluto
+        // (DigitalConciergeController no tiene guards — el visitante habla con
+        // la IA de forma anónima) — TenantContextService no puede resolver el
+        // condominio del caller. La visita ya fue creada y su id ya vive en
+        // esta MISMA sesión (resource-derived), así que se bypassa el scoping
+        // por tenant en vez de romper el flujo de aprobación.
+        await this.visitsService.checkIn(session.createdVisit.id, { skipTenantScope: true });
         this.logger.log(`✅ Visit ${session.createdVisit.id} check-in registered (status: ACTIVE, usedCount incremented)`);
       } else {
         // Si se niega, solo cambiar el status
@@ -305,7 +312,8 @@ export class DigitalConciergeService {
         
         if (residentIsValid) {
           // Actualizar el host de la visita al residente que respondió
-          const updatedVisit = await this.visitsService.update(session.createdVisit.id, { hostId: residentId });
+          // (sin sesión de usuario — ver comentario del checkIn más arriba)
+          const updatedVisit = await this.visitsService.update(session.createdVisit.id, { hostId: residentId }, { skipTenantScope: true });
           this.logger.log(`✅ Visit host updated to residentId: ${residentId}, new host: ${updatedVisit.host.name}`);
         } else {
           this.logger.warn(`⚠️ ResidentId ${residentId} no está en la lista de residentes notificados`);
@@ -653,7 +661,11 @@ export class DigitalConciergeService {
         return 'Sin contexto histórico previo para esta casa.';
       }
 
-      const visits = await this.visitsService.findAll({ familyId: family.id });
+      // Sin sesión de usuario (ver comentario en respondToVisitor) — ya está
+      // acotado a UNA familia resource-derived (familyId), que a su vez
+      // pertenece a un único condominio, así que el bypass no reabre el leak
+      // cross-tenant que motivó esta tarea.
+      const visits = await this.visitsService.findAll({ familyId: family.id }, { skipTenantScope: true });
       const today = new Date();
       
       // Filtrar pre-aprobadas para hoy

--- a/backend/src/migrations/1783887400000-BackfillVisitsOrganizationId.ts
+++ b/backend/src/migrations/1783887400000-BackfillVisitsOrganizationId.ts
@@ -1,0 +1,80 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * Backfill de `organizationId` en `visits` (branch fix/visits-tenant-isolation
+ * — hardening del aislamiento multi-tenant de Fase 0, tarea #19).
+ *
+ * El módulo Visits quedó fuera del scoping por tenant de Fase 0 (ver
+ * docstring en src/visits/entities/visit.entity.ts): la columna
+ * `organizationId` existe desde entonces pero nunca se estampó, así que TODAS
+ * las visitas creadas hasta ahora tienen `organizationId = NULL`.
+ *
+ * Este backfill usa el MISMO criterio de derivación que `VisitsService.create`
+ * tras el fix (ver su docstring):
+ *   1. La familia del host (`families.organizationId`, ya scopeada desde
+ *      Fase 0) — fuente primaria, cubre la enorme mayoría de las visitas
+ *      (residentes con familia asignada).
+ *   2. Si el host no tiene familia (o la familia todavía no tiene
+ *      organización — legacy pre-Fase 0), fallback a la membresía de
+ *      organización del host (tabla `member`, creada por el plugin
+ *      `organization` de better-auth — mismo criterio que
+ *      `resolveOrganizationIdForUser` en
+ *      src/common/tenant/tenant-context.util.ts).
+ *
+ * Visitas cuyo host no tenga NI familia con organización NI membresía
+ * resoluble quedan con `organizationId = NULL` — mismo "cajón" visible solo
+ * por super-admin (y otros recursos sin organización) que ya usa el resto del
+ * sistema desde Fase 0 (ver `scopeWhere`/`stampOrganizationId`), no es un caso
+ * nuevo que este backfill deba inventar una solución distinta para.
+ */
+export class BackfillVisitsOrganizationId1783887400000 implements MigrationInterface {
+    name = 'BackfillVisitsOrganizationId1783887400000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Paso 1: derivar organizationId desde la familia del host.
+        await queryRunner.query(`
+            UPDATE "visits" v
+            SET "organizationId" = f."organizationId"
+            FROM "user" u
+            INNER JOIN "families" f ON f."id" = u."familyId"
+            WHERE v."hostId" = u."id"
+              AND v."organizationId" IS NULL
+              AND f."organizationId" IS NOT NULL
+        `);
+
+        // Paso 2 (fallback): visitas cuyo host no tiene familia con
+        // organización — resolver desde la membresía de organización del host
+        // (tabla `member` de better-auth). Esta tabla la crea el CLI de
+        // better-auth (npx @better-auth/cli migrate); si aún no corrió en este
+        // entorno, no rompemos la migración — se deja como "cajón sin
+        // organización" (mismo criterio de resolveOrganizationIdForUser).
+        try {
+            await queryRunner.query(`
+                UPDATE "visits" v
+                SET "organizationId" = m."organizationId"
+                FROM "user" u
+                INNER JOIN LATERAL (
+                    SELECT "organizationId"
+                    FROM "member"
+                    WHERE "userId" = u."id"
+                    ORDER BY "createdAt" ASC
+                    LIMIT 1
+                ) m ON true
+                WHERE v."hostId" = u."id"
+                  AND v."organizationId" IS NULL
+            `);
+        } catch (error) {
+            // Tabla `member` no existe todavía en este entorno (better-auth
+            // CLI no ha corrido) — no bloquear el resto de la migración.
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Backfill de datos, no de esquema: no hay forma de distinguir, entre
+        // las visitas que hoy tienen organizationId poblado, cuáles lo tenían
+        // ya (estampadas por VisitsService.create tras el fix) de cuáles lo
+        // recibieron de este backfill — revertir a NULL sería destructivo y
+        // reintroduciría el bug que esta migración corrige. Down() es
+        // deliberadamente un no-op.
+    }
+}

--- a/backend/src/visits/visits.service.ts
+++ b/backend/src/visits/visits.service.ts
@@ -10,7 +10,32 @@ import { VehiclesService } from '../vehicles/vehicles.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/entities/notification.entity';
 import { Vehicle } from '../vehicles/entities/vehicle.entity';
+import { TenantContextService } from '../common/tenant/tenant-context.service';
+import { scopeWhere, applyTenantFilter, stampOrganizationId } from '../common/tenant/tenant-context.util';
 import * as crypto from 'crypto';
+
+/**
+ * Opciones internas para los métodos de VisitsService que son compartidos
+ * entre el flujo autenticado (VisitsController, humano con sesión) y flujos
+ * SIN sesión de usuario:
+ *  - Worker LPR (DetectionsService, protegido con ServiceApiKeyGuard — NO
+ *    puebla `request.user`, ver service-api-key.guard.ts).
+ *  - Conserje Digital (DigitalConciergeController — sin NINGÚN guard, el
+ *    visitante habla con la IA de forma anónima desde el citofono).
+ *
+ * Para ambos, `TenantContextService.getContext()` resuelve
+ * `{organizationId: null, isSuperAdmin: false}` (no hay forma de saber el
+ * tenant desde `request.user`, que no existe). Aplicar el scoping por tenant
+ * ahí de todas formas rompería esos flujos (ningún Visit real calzaría con
+ * `organizationId IS NULL` tras el backfill). `skipTenantScope` es la válvula
+ * de escape EXPLÍCITA para esos call-sites puntuales (ver DetectionsService y
+ * DigitalConciergeService) — mismo criterio que
+ * `CamerasService.resolveCameraByIdOrMount`/`getCameraByIdOrMount`, dejados
+ * deliberadamente sin scoping por la misma razón (ver su docstring).
+ */
+interface TenantScopeOptions {
+  skipTenantScope?: boolean;
+}
 
 @Injectable()
 export class VisitsService {
@@ -23,7 +48,37 @@ export class VisitsService {
     private readonly familiesService: FamiliesService,
     private readonly vehiclesService: VehiclesService,
     private readonly notificationsService: NotificationsService,
+    // Tarea de aislamiento tenant (branch fix/visits-tenant-isolation, ver
+    // docs/modulos/auth-multitenant.md §7): scoping por tenant en
+    // create/findAll/findPending/findOne/findByQRCode/findByPlate/
+    // validateAccess/update/checkIn/checkOut (ver métodos abajo e
+    // interfaz TenantScopeOptions sobre los bypass puntuales).
+    private readonly tenantContext: TenantContextService,
   ) {}
+
+  /**
+   * Búsqueda interna SIN scoping por tenant — únicamente para los call-sites
+   * resource-derived (worker LPR / Conserje Digital, ver TenantScopeOptions)
+   * que ya operan sobre un `id` de Visit resuelto por otra vía (plate/QR/
+   * sesión propia), no por enumeración. NO exponer directamente al
+   * controller.
+   */
+  private async loadVisitEntity(id: string, options?: TenantScopeOptions): Promise<Visit> {
+    const where = options?.skipTenantScope
+      ? { id }
+      : scopeWhere({ id }, await this.tenantContext.getContext());
+
+    const visit = await this.visitRepository.findOne({
+      where,
+      relations: ['host', 'family', 'vehicle'],
+    });
+
+    if (!visit) {
+      throw new NotFoundException(`Visita con ID ${id} no encontrada`);
+    }
+
+    return visit;
+  }
 
   /**
    * Crear una nueva visita (vehicular o peatonal)
@@ -34,7 +89,7 @@ export class VisitsService {
     // Validar que la fecha de inicio sea anterior a la fecha de fin
     const from = new Date(validFrom);
     const until = new Date(validUntil);
-    
+
     if (from >= until) {
       throw new BadRequestException('La fecha de inicio debe ser anterior a la fecha de fin');
     }
@@ -63,6 +118,20 @@ export class VisitsService {
       maxUses: createVisitDto.maxUses !== undefined ? createVisitDto.maxUses : null,
       usedCount: 0,
     });
+
+    // Tarea de aislamiento tenant: el organizationId se deriva PRIORITARIAMENTE
+    // de la familia del host (recurso ya resuelto arriba) y solo si no tiene
+    // familia se cae al tenant del creador (ctx). Esto es deliberado: `create`
+    // lo invocan tanto el flujo autenticado (conserje/admin crea la visita
+    // desde su propio condominio — ver VisitsController) como el Conserje
+    // Digital (visitante anónimo en el citofono, SIN sesión de usuario — ver
+    // DigitalConciergeController, no tiene guards). Para este último,
+    // `tenantContext.getContext()` no puede resolver nada (no hay
+    // `request.user`), así que la familia del host (que si vive en un
+    // condominio ya tiene su `organizationId`, scopeado desde Fase 0) es la
+    // única fuente confiable en ambos casos.
+    const ctx = await this.tenantContext.getContext();
+    stampOrganizationId(visit, { ...ctx, organizationId: family?.organizationId ?? ctx.organizationId });
 
     // Generar código QR único para TODAS las visitas (peatonales y vehiculares)
     // Para vehiculares sirve como respaldo si el LPR falla
@@ -124,12 +193,17 @@ export class VisitsService {
     type?: VisitType;
     hostId?: string;
     familyId?: string;
-  }): Promise<Visit[]> {
+  }, options?: TenantScopeOptions): Promise<Visit[]> {
     const query = this.visitRepository.createQueryBuilder('visit')
       .leftJoinAndSelect('visit.host', 'host')
       .leftJoinAndSelect('visit.family', 'family')
       .leftJoinAndSelect('visit.vehicle', 'vehicle')
       .orderBy('visit.createdAt', 'DESC');
+
+    if (!options?.skipTenantScope) {
+      const ctx = await this.tenantContext.getContext();
+      applyTenantFilter(query, 'visit', ctx);
+    }
 
     if (filters?.status) {
       query.andWhere('visit.status = :status', { status: filters.status });
@@ -161,11 +235,12 @@ export class VisitsService {
    * Obtener visitas pendientes (programadas para hoy o futuro)
    */
   async findPending(): Promise<Visit[]> {
+    const ctx = await this.tenantContext.getContext();
     return await this.visitRepository.find({
-      where: {
+      where: scopeWhere({
         status: VisitStatus.PENDING,
         validFrom: MoreThan(new Date()),
-      },
+      }, ctx),
       relations: ['host', 'family', 'vehicle'],
       order: { validFrom: 'ASC' },
     });
@@ -175,16 +250,7 @@ export class VisitsService {
    * Obtener una visita por ID
    */
   async findOne(id: string): Promise<Visit> {
-    const visit = await this.visitRepository.findOne({
-      where: { id },
-      relations: ['host', 'family', 'vehicle'],
-    });
-
-    if (!visit) {
-      throw new NotFoundException(`Visita con ID ${id} no encontrada`);
-    }
-
-    return visit;
+    return this.loadVisitEntity(id);
   }
 
   /**
@@ -192,8 +258,9 @@ export class VisitsService {
    * Las visitas vehiculares también tienen QR como respaldo del LPR
    */
   async findByQRCode(qrCode: string): Promise<Visit> {
+    const ctx = await this.tenantContext.getContext();
     const visit = await this.visitRepository.findOne({
-      where: { qrCode },
+      where: scopeWhere({ qrCode }, ctx),
       relations: ['host', 'family', 'vehicle'],
     });
 
@@ -207,19 +274,25 @@ export class VisitsService {
   /**
    * Buscar visita por patente (para visitas vehiculares)
    */
-  async findByPlate(plate: string): Promise<Visit | null> {
-    const visit = await this.visitRepository
+  async findByPlate(plate: string, options?: TenantScopeOptions): Promise<Visit | null> {
+    const query = this.visitRepository
       .createQueryBuilder('visit')
       .leftJoinAndSelect('visit.vehicle', 'vehicle')
       .leftJoinAndSelect('visit.host', 'host')
       .leftJoinAndSelect('visit.family', 'family')
       .where('vehicle.plate = :plate', { plate })
-      .andWhere('visit.status IN (:...statuses)', { 
-        statuses: [VisitStatus.PENDING, VisitStatus.ACTIVE, VisitStatus.READY_FOR_REENTRY] 
+      .andWhere('visit.status IN (:...statuses)', {
+        statuses: [VisitStatus.PENDING, VisitStatus.ACTIVE, VisitStatus.READY_FOR_REENTRY]
       })
       .andWhere('visit.validFrom <= :now', { now: new Date() })
-      .andWhere('visit.validUntil >= :now', { now: new Date() })
-      .getOne();
+      .andWhere('visit.validUntil >= :now', { now: new Date() });
+
+    if (!options?.skipTenantScope) {
+      const ctx = await this.tenantContext.getContext();
+      applyTenantFilter(query, 'visit', ctx);
+    }
+
+    const visit = await query.getOne();
 
     return visit;
   }
@@ -227,10 +300,14 @@ export class VisitsService {
   /**
    * Actualizar solo el estado de una visita
    * Método simplificado para cambios rápidos de estado
+   *
+   * Único caller: DigitalConciergeService (flujo del citofono, sin sesión de
+   * usuario — ver TenantScopeOptions), por eso la carga es siempre
+   * resource-derived (sin scoping por tenant).
    */
   async updateStatus(id: string, status: string): Promise<Visit> {
-    const visit = await this.findOne(id);
-    
+    const visit = await this.loadVisitEntity(id, { skipTenantScope: true });
+
     // Convertir string a enum de VisitStatus
     const validStatuses = ['pending', 'active', 'ready', 'completed', 'cancelled', 'expired', 'denied'];
     if (!validStatuses.includes(status)) {
@@ -244,8 +321,8 @@ export class VisitsService {
   /**
    * Actualizar una visita
    */
-  async update(id: string, updateVisitDto: UpdateVisitDto): Promise<Visit> {
-    const visit = await this.findOne(id);
+  async update(id: string, updateVisitDto: UpdateVisitDto, options?: TenantScopeOptions): Promise<Visit> {
+    const visit = await this.loadVisitEntity(id, options);
 
     // Actualizar campos básicos de la visita
     if (updateVisitDto.type !== undefined) {
@@ -282,16 +359,16 @@ export class VisitsService {
       console.log(`[VISITS] 🔄 Actualizando host de visita ${id}`);
       console.log(`[VISITS] Host anterior: ${visit.host?.name} (${visit.host?.id})`);
       console.log(`[VISITS] Nuevo hostId: ${updateVisitDto.hostId}`);
-      
+
       const host = await this.usersService.findOne(updateVisitDto.hostId);
       if (!host) {
         throw new NotFoundException(`Usuario anfitrión con ID ${updateVisitDto.hostId} no encontrado`);
       }
       visit.host = host;
-      
+
       // Actualizar automáticamente la familia del nuevo anfitrión
       visit.family = host.family || null;
-      
+
       console.log(`[VISITS] ✅ Nuevo host asignado: ${host.name} (${host.id})`);
       console.log(`[VISITS] Familia: ${visit.family?.name || 'Sin familia'}`);
     }
@@ -306,7 +383,7 @@ export class VisitsService {
       if (updateVisitDto.vehiclePlate) {
         // Si hay patente, buscar o crear vehículo
         let vehicle = await this.vehiclesService.findByPlate(updateVisitDto.vehiclePlate);
-        
+
         if (!vehicle) {
           // Crear nuevo vehículo si no existe
           vehicle = await this.vehiclesService.create({
@@ -324,7 +401,7 @@ export class VisitsService {
             color: updateVisitDto.vehicleColor || vehicle.color || undefined,
           });
         }
-        
+
         visit.vehicle = vehicle;
       } else {
         visit.vehicle = null;
@@ -354,20 +431,20 @@ export class VisitsService {
     }
 
     const savedVisit = await this.visitRepository.save(visit);
-    
+
     // Log de confirmación si se actualizó el host
     if (updateVisitDto.hostId !== undefined) {
       console.log(`[VISITS] 💾 Visita guardada con nuevo host: ${savedVisit.host.name} (${savedVisit.host.id})`);
     }
-    
+
     return savedVisit;
   }
 
   /**
    * Registrar entrada de una visita
    */
-  async checkIn(id: string): Promise<Visit> {
-    const visit = await this.findOne(id);
+  async checkIn(id: string, options?: TenantScopeOptions): Promise<Visit> {
+    const visit = await this.loadVisitEntity(id, options);
     const now = new Date();
 
     // Validar que la visita esté en estado PENDING, READY_FOR_REENTRY o COMPLETED (para reusos)
@@ -400,10 +477,10 @@ export class VisitsService {
     const savedVisit = await this.visitRepository.save(visit);
 
     // Notificar al host sobre la llegada de la visita
-    const usageInfo = visit.maxUses !== null 
-      ? ` (Uso ${visit.usedCount}/${visit.maxUses})` 
+    const usageInfo = visit.maxUses !== null
+      ? ` (Uso ${visit.usedCount}/${visit.maxUses})`
       : '';
-    
+
     await this.notificationsService.create({
       recipientId: visit.host.id,
       type: NotificationType.VISIT_CHECK_IN,
@@ -426,8 +503,8 @@ export class VisitsService {
   /**
    * Registrar salida de una visita
    */
-  async checkOut(id: string): Promise<Visit> {
-    const visit = await this.findOne(id);
+  async checkOut(id: string, options?: TenantScopeOptions): Promise<Visit> {
+    const visit = await this.loadVisitEntity(id, options);
 
     // Validar que la visita esté en estado ACTIVE
     if (visit.status !== VisitStatus.ACTIVE) {
@@ -435,7 +512,7 @@ export class VisitsService {
     }
 
     visit.exitTime = new Date();
-    
+
     // Si aún tiene usos disponibles, marcar como READY_FOR_REENTRY para permitir reingreso
     // Si ya no tiene usos, marcar como COMPLETED
     if (visit.maxUses === null || visit.usedCount < visit.maxUses) {
@@ -447,10 +524,10 @@ export class VisitsService {
     const savedVisit = await this.visitRepository.save(visit);
 
     // Notificar al host sobre la salida de la visita
-    const statusInfo = savedVisit.status === VisitStatus.COMPLETED 
-      ? 'Visita completada (sin usos disponibles).' 
+    const statusInfo = savedVisit.status === VisitStatus.COMPLETED
+      ? 'Visita completada (sin usos disponibles).'
       : 'Podrá reingresar si está dentro del período válido.';
-    
+
     await this.notificationsService.create({
       recipientId: visit.host.id,
       type: NotificationType.VISIT_CHECK_OUT,
@@ -474,7 +551,7 @@ export class VisitsService {
    * Cancelar una visita
    */
   async cancel(id: string): Promise<Visit> {
-    const visit = await this.findOne(id);
+    const visit = await this.loadVisitEntity(id);
 
     if (visit.status === VisitStatus.COMPLETED) {
       throw new BadRequestException('No se puede cancelar una visita completada');
@@ -494,14 +571,14 @@ export class VisitsService {
    * Eliminar una visita
    */
   async remove(id: string): Promise<void> {
-    const visit = await this.findOne(id);
+    const visit = await this.loadVisitEntity(id);
     await this.visitRepository.remove(visit);
   }
 
   /**
    * Validar acceso de una visita (por QR o patente)
    */
-  async validateAccess(identifier: string, type: 'qr' | 'plate'): Promise<{
+  async validateAccess(identifier: string, type: 'qr' | 'plate', options?: TenantScopeOptions): Promise<{
     valid: boolean;
     visit?: Visit;
     message: string;
@@ -515,7 +592,7 @@ export class VisitsService {
         return { valid: false, message: 'Código QR no válido' };
       }
     } else if (type === 'plate') {
-      visit = await this.findByPlate(identifier);
+      visit = await this.findByPlate(identifier, options);
       if (!visit) {
         return { valid: false, message: 'Patente no autorizada' };
       }
@@ -543,10 +620,10 @@ export class VisitsService {
     // Verificar período de validez ANTES de verificar si está marcada como expirada
     // Esto permite marcar como expirada una visita que aún no lo está
     if (now < visit.validFrom) {
-      return { 
-        valid: false, 
-        visit, 
-        message: `Visita válida desde ${visit.validFrom.toLocaleString()}` 
+      return {
+        valid: false,
+        visit,
+        message: `Visita válida desde ${visit.validFrom.toLocaleString()}`
       };
     }
 
@@ -555,7 +632,7 @@ export class VisitsService {
       if (visit.status === VisitStatus.PENDING || visit.status === VisitStatus.ACTIVE || visit.status === VisitStatus.READY_FOR_REENTRY) {
         visit.status = VisitStatus.EXPIRED;
         await this.visitRepository.save(visit);
-        
+
         // Notificar al host
         await this.notificationsService.create({
           recipientId: visit.host.id,
@@ -587,10 +664,10 @@ export class VisitsService {
       }
     }
 
-    return { 
-      valid: true, 
-      visit, 
-      message: 'Acceso autorizado' 
+    return {
+      valid: true,
+      visit,
+      message: 'Acceso autorizado'
     };
   }
 


### PR DESCRIPTION
## Fix — Aislamiento tenant del módulo Visits (leak de datos)

Cierra un **leak de datos cross-tenant** en el módulo Visits, destapado por la verificación E2E de Fase 1: `VisitsService.create` no estampaba `organizationId` (las visitas quedaban con `NULL`) y los reads no filtraban por tenant → cualquier usuario con `visits.read` veía las visitas de **todos** los condominios.

### Cambios
- **`create` estampa `organizationId` server-side**, derivado de `family.organizationId` del **host** (fallback: tenant del creador). Se eligió la familia del host y no el tenant del creador porque el conserje digital crea visitas sin sesión de usuario — con el tenant del creador esas visitas (el flujo principal) habrían quedado en `NULL`. Nunca sale del body/DTO.
- **Todos los reads/writes de `Visit` scopeados por tenant** (`findAll`, `findPending`, `findOne`, `findByQRCode`, `findByPlate`, `validateAccess`, `update`, `checkIn`, `checkOut`, `cancel`, `remove`) vía `TenantContextService`, con bypass explícito `{ skipTenantScope: true }` **solo** en los call-sites sin sesión (worker LPR por api-key; conserje digital) — inalcanzable por payload.
- **Migración de backfill** para las visitas existentes con `organizationId NULL` (deriva de la familia del host, fallback a membresía).

### Verificación (datos reales, DB aislada)
- `create` estampa el org correcto en 2 condominios; `GET /visits` y `GET /visits/:id` de un condominio no ven los del otro (404 cross-tenant); check-in cross-tenant → 404; super-admin ve todo; backfill deja las visitas legacy con su org correcto. Type-check y build limpios.

### Auditoría de seguridad
Aprobado: read leak cerrado completo, bypass acotado e inalcanzable por payload, estampado server-side.

### Known issue (MEDIO, follow-up — no bloqueante)
`UsersService.findOne` (usado para resolver `hostId`) no está scopeado por tenant → un admin del condominio A que conozca un UUID de un host del condominio B podría crear una visita atribuida a B (y una credencial de acceso). Mitigado: el UUID no es enumerable (122 bits). Se cerrará junto con las tools write del agente en Fase 2 (mismo vector vía `notificar_residente`), validando `host.family.organizationId === ctx.organizationId`.

> Nota de merge: `detections.service.ts` también lo toca el PR #49 (Fase 1); habrá un conflicto de merge menor a resolver al mergear el segundo.
