### PR TITLE
Fase 2 (nucleo): agente completo - tools + autonomia

### DIFF
--- a/backend/src/agent/agent.module.ts
+++ b/backend/src/agent/agent.module.ts
@@ -1,11 +1,16 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
+import { DetectionsModule } from '../detections/detections.module';
 import { ConciergeAuthGuard } from '../digital-concierge/guards/concierge-auth.guard';
 import { DigitalConciergeModule } from '../digital-concierge/digital-concierge.module';
 import { FamiliesModule } from '../families/families.module';
 import { HubModule } from '../hub/hub.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { UsersModule } from '../users/users.module';
+import { VehiclesModule } from '../vehicles/vehicles.module';
+import { VisitsModule } from '../visits/visits.module';
 import {
   AGENT_LANGUAGE_MODEL,
   createAgentLanguageModel,
@@ -13,10 +18,17 @@ import {
 import { AgentController } from './agent.controller';
 import { AgentRunnerService } from './agent-runner.service';
 import { AuthorizedContextFactory } from './authorized-context.factory';
+import { PendingAction } from './entities/pending-action.entity';
+import { PendingActionsController } from './pending-actions.controller';
+import { PendingActionsService } from './pending-actions.service';
 import { ToolDispatcherService } from './tool-dispatcher.service';
 import { ToolRegistryService } from './tool-registry.service';
 import { VIGILIA_TOOLS } from './tool-registry.token';
+import { AbrirAccesoTool } from './tools/abrir-acceso.tool';
 import { BuscarResidenteTool } from './tools/buscar-residente.tool';
+import { ConsultarAccesosRecientesTool } from './tools/consultar-accesos-recientes.tool';
+import { ConsultarVehiculoTool } from './tools/consultar-vehiculo.tool';
+import { ConsultarVisitasTool } from './tools/consultar-visitas.tool';
 import { FinalizarLlamadaTool } from './tools/finalizar-llamada.tool';
 import { GuardarDatosVisitanteTool } from './tools/guardar-datos-visitante.tool';
 import { NotificarResidenteTool } from './tools/notificar-residente.tool';
@@ -56,13 +68,22 @@ import { ReenviarNotificacionTool } from './tools/reenviar-notificacion.tool';
  */
 @Module({
   imports: [
+    TypeOrmModule.forFeature([PendingAction]),
     UsersModule,
     FamiliesModule,
     HubModule,
     AuthModule,
+    NotificationsModule,
+    // Fase 2, Bloque F2.1 (docs/modulos/agente-cerebro.md §12): las 3 tools de
+    // consulta nuevas inyectan estos servicios de dominio directo — ninguno
+    // importa AgentModule de vuelta, así que no hace falta forwardRef (a
+    // diferencia de DigitalConciergeModule más abajo).
+    VehiclesModule,
+    VisitsModule,
+    DetectionsModule,
     forwardRef(() => DigitalConciergeModule),
   ],
-  controllers: [AgentController],
+  controllers: [AgentController, PendingActionsController],
   providers: [
     // Guard de transporte reusado (ver docstring de la clase arriba). Sus
     // dependencias (HubAuthGuard, AuthGuard) llegan vía los `imports` de
@@ -75,6 +96,15 @@ import { ReenviarNotificacionTool } from './tools/reenviar-notificacion.tool';
     NotificarResidenteTool,
     ReenviarNotificacionTool,
     FinalizarLlamadaTool,
+    ConsultarVehiculoTool,
+    ConsultarVisitasTool,
+    ConsultarAccesosRecientesTool,
+    // Fase 2, Bloque F2.2 (docs/modulos/agente-cerebro.md §12): apertura física
+    // de accesos con autonomía condicional (`requiresApproval` dinámico) —
+    // inyecta `DigitalConciergeService` (igual que `finalizar_llamada`/
+    // `notificar_residente`, ver forwardRef abajo) + `HubGateway` (ya exportado
+    // por `HubModule`, importado arriba).
+    AbrirAccesoTool,
     {
       provide: VIGILIA_TOOLS,
       useFactory: (
@@ -83,12 +113,20 @@ import { ReenviarNotificacionTool } from './tools/reenviar-notificacion.tool';
         notificarResidente: NotificarResidenteTool,
         reenviarNotificacion: ReenviarNotificacionTool,
         finalizarLlamada: FinalizarLlamadaTool,
+        consultarVehiculo: ConsultarVehiculoTool,
+        consultarVisitas: ConsultarVisitasTool,
+        consultarAccesosRecientes: ConsultarAccesosRecientesTool,
+        abrirAcceso: AbrirAccesoTool,
       ) => [
         buscarResidente,
         guardarDatosVisitante,
         notificarResidente,
         reenviarNotificacion,
         finalizarLlamada,
+        consultarVehiculo,
+        consultarVisitas,
+        consultarAccesosRecientes,
+        abrirAcceso,
       ],
       inject: [
         BuscarResidenteTool,
@@ -96,9 +134,20 @@ import { ReenviarNotificacionTool } from './tools/reenviar-notificacion.tool';
         NotificarResidenteTool,
         ReenviarNotificacionTool,
         FinalizarLlamadaTool,
+        ConsultarVehiculoTool,
+        ConsultarVisitasTool,
+        ConsultarAccesosRecientesTool,
+        AbrirAccesoTool,
       ],
     },
     ToolRegistryService,
+
+    // Fase 2, Bloque F2.1: mecanismo de autonomía/aprobación —
+    // `ToolDispatcherService` la usa para escalar (`requiresApproval`), el
+    // endpoint de aprobación (`PendingActionsController`) la usa para
+    // resolver. Ver su docstring sobre por qué NO depende de vuelta de
+    // `ToolDispatcherService` (evita un ciclo de providers).
+    PendingActionsService,
     ToolDispatcherService,
 
     // Modelo del AI SDK — provider-agnóstico, configurable por env (ver
@@ -115,6 +164,10 @@ import { ReenviarNotificacionTool } from './tools/reenviar-notificacion.tool';
   // Bloque A2b: `DigitalConciergeController` (otro módulo, ver forwardRef
   // arriba) necesita estos tres para reemplazar su `switch` por el
   // dispatcher del catálogo — ver digital-concierge.module.ts.
-  exports: [ToolDispatcherService, ToolRegistryService, AuthorizedContextFactory],
+  exports: [
+    ToolDispatcherService,
+    ToolRegistryService,
+    AuthorizedContextFactory,
+  ],
 })
 export class AgentModule {}

--- a/backend/src/agent/entities/pending-action.entity.ts
+++ b/backend/src/agent/entities/pending-action.entity.ts
@@ -1,0 +1,148 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Fase 2, Bloque F2.1 (docs/modulos/agente-cerebro.md §12): estados del ciclo
+ * de vida de una `PendingAction`.
+ *
+ *   pending   → creada por `ToolDispatcherService` cuando `tool.requiresApproval`
+ *               es `true`; todavía no se decidió nada.
+ *   approved  → un humano autorizado aprobó, pero la ejecución de la tool aún
+ *               no terminó (estado transitorio dentro de `PendingActionsService.approve`,
+ *               nunca debería observarse "en reposo" salvo un crash a mitad de la ejecución).
+ *   rejected  → un humano autorizado rechazó — estado terminal, nunca se ejecuta.
+ *   executed  → la tool ya corrió y `result` tiene su salida — estado terminal,
+ *               es la base de la idempotencia (`approve` sobre una acción ya
+ *               `executed` NO vuelve a ejecutar, devuelve `result`).
+ *   failed    → (revisión pre-F2.2, fix del bloqueo detectado en QA) `tool.execute()`
+ *               lanzó DESPUÉS de la aprobación — NO es terminal: `approve()`
+ *               reclama también desde `failed` (ver su docstring), permitiendo
+ *               reintentar la misma acción sin crear una nueva. `lastError`
+ *               guarda el motivo del último fallo.
+ *   expired   → (revisión pre-F2.2) el contexto que originó la escalada dejó de
+ *               ser válido antes de poder ejecutar (p.ej. la `ConciergeSession`
+ *               del citófono ya terminó) — terminal, NUNCA se ejecuta la tool
+ *               desde acá. Crítico para que el portón (F2.2) no abra por una
+ *               llamada que ya colgó.
+ */
+export enum PendingActionStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  EXECUTED = 'executed',
+  FAILED = 'failed',
+  EXPIRED = 'expired',
+}
+
+/**
+ * Fase 2, Bloque F2.1 (docs/modulos/agente-cerebro.md §12): mecanismo de
+ * autonomía/aprobación del agente-cerebro. Hasta este bloque
+ * `VigiliaTool.requiresApproval` existía en el contrato (§5 del diseño) pero
+ * estaba MUERTO — ningún consumidor lo leía. Esta entidad es lo que
+ * `ToolDispatcherService.execute` crea en vez de ejecutar directamente
+ * cuando una tool declara `requiresApproval: true` (ver su docstring).
+ *
+ * Diseño deliberado de cada columna:
+ *  - `tenantId`: SIEMPRE copiado de `ctx.tenantId` en el momento de crear la
+ *    acción (nunca del input) — mismo criterio de aislamiento que el resto
+ *    del catálogo (§5/§6 del diseño). Nullable por el mismo "cajón sin
+ *    condominio" que el resto de columnas `organizationId`/`tenantId` del
+ *    sistema (hub aún no asociado, etc.).
+ *  - `sessionId`: nullable porque no toda tool que pudiera requerir
+ *    aprobación opera sobre una `ConciergeSession` (ver el mismo comentario
+ *    en `AuthorizedContext.sessionId` — p.ej. el canal de texto de
+ *    `AgentController` no siempre trae una).
+ *  - `input`: el input YA VALIDADO por `tool.inputSchema` (post-Zod) — nunca
+ *    el `rawInput` sin validar — para que la ejecución diferida en
+ *    `approve()` no tenga que re-validar contra un modelo que pudo cambiar
+ *    de opinión mientras esperaba aprobación.
+ *  - `requestId`: `ctx.requestId` del turno que originó la escalada —
+ *    correlación de auditoría (mismo campo que ya usa `logs.service` para
+ *    todo el resto del catálogo). La idempotencia real de la EJECUCIÓN no
+ *    depende de este campo sino de `status` (ver `PendingActionsService.approve`,
+ *    actualización atómica condicionada a `status != executed`).
+ *  - `contextSnapshot`: el `AuthorizedContext` COMPLETO que autorizó la
+ *    escalada. Necesario porque `approve()` ocurre en un turno HTTP
+ *    completamente distinto (el residente/conserje aprobando desde su propia
+ *    sesión) y `tool.execute(ctx, input)` necesita un `ctx` con la forma
+ *    correcta (tenantId/sessionId/role/scopes del llamador ORIGINAL, no del
+ *    aprobador) para que la tool se comporte igual que si hubiera ejecutado
+ *    en el momento. No es un campo listado explícitamente en el encargo de
+ *    la tarea, pero es indispensable para poder re-invocar `execute()` con
+ *    fidelidad — ninguno de sus campos es secreto (son los mismos que ya
+ *    viajan en claro por `AuthorizedContext`).
+ *  - `result`: `null` hasta `executed`; guarda la salida YA validada por
+ *    `tool.outputSchema` — es lo que se devuelve sin re-ejecutar ante una
+ *    segunda aprobación o una nueva consulta de estado.
+ */
+@Entity({ name: 'pending_actions' })
+export class PendingAction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: 'uuid', nullable: true })
+  tenantId: string | null;
+
+  @Index()
+  @Column({ type: 'uuid', nullable: true })
+  sessionId: string | null;
+
+  @Column({ type: 'varchar', length: 128 })
+  toolName: string;
+
+  @Column({ type: 'jsonb' })
+  input: unknown;
+
+  @Column({ type: 'varchar', length: 64 })
+  requestId: string;
+
+  @Index()
+  @Column({
+    type: 'enum',
+    enum: PendingActionStatus,
+    default: PendingActionStatus.PENDING,
+  })
+  status: PendingActionStatus;
+
+  // `unknown` a secas (no `Record<string, unknown>`): TypeORM's
+  // `QueryDeepPartialEntity`/`DeepPartial` para columnas jsonb exige el tipo
+  // exacto `unknown` en `create()`/`update()` — `Record<string, unknown>`
+  // rompe la asignación de `ctx: AuthorizedContext` (una interfaz, sin index
+  // signature) sin un cast extra. `unknown` ya admite `null`
+  // estructuralmente, así que `| null` es redundante para TypeScript (lint
+  // `no-redundant-type-constituents`) — se documenta acá en vez de en el
+  // tipo, ya que la columna SÍ es `nullable: true` en Postgres.
+  @Column({ type: 'jsonb', nullable: true })
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  contextSnapshot: unknown | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  result: unknown | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @Column({ type: 'uuid', nullable: true })
+  resolvedBy: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  resolvedAt: Date | null;
+
+  /**
+   * Motivo del último fallo/expiración (FIX 2/FIX 3, revisión pre-F2.2) —
+   * `null` mientras la acción no haya pasado por `failed`/`expired`. Guarda
+   * el mensaje de error de `tool.execute()` (estado `failed`) o la razón de
+   * invalidez de contexto (estado `expired`, ver
+   * `PendingActionsService.validateExecutionContext`). Solo texto de
+   * diagnóstico — nunca un campo que la tool o el modelo puedan escribir.
+   */
+  @Column({ type: 'text', nullable: true })
+  lastError: string | null;
+}

--- a/backend/src/agent/pending-actions.controller.ts
+++ b/backend/src/agent/pending-actions.controller.ts
@@ -1,0 +1,145 @@
+import {
+  Controller,
+  Logger,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import type { Request } from 'express';
+import { AuthGuard } from '../auth/auth.guard';
+import { RequirePermissions } from '../auth/decorators/permissions.decorator';
+import { AuthorizationGuard } from '../auth/guards/authorization.guard';
+import { TenantContextService } from '../common/tenant/tenant-context.service';
+import { PendingActionsService } from './pending-actions.service';
+
+/** `Request` con el `user` que `AuthGuard` ya adjunta (sesión humana JWT/better-auth). */
+type AuthenticatedRequest = Request & { user?: { id: string } };
+
+/**
+ * Endpoint de aprobación del mecanismo de autonomía (Fase 2, Bloque F2.1 —
+ * docs/modulos/agente-cerebro.md §12). Deliberadamente usa `AuthGuard`
+ * "plano" (sesión humana), NO `ConciergeAuthGuard`: un hub físico es quien
+ * ESCALA una acción (vía `ToolDispatcherService`), pero solo un humano
+ * (residente/conserje) puede aprobarla o rechazarla — igual criterio que
+ * distingue "quien reporta" de "quien decide" en el resto del sistema.
+ *
+ * Reusa el permiso `digital-concierge.manage` (ya sembrado en
+ * `DEFAULT_PERMISSIONS`, sin usar hasta este bloque) — "aprobar/rechazar una
+ * acción del agente" encaja en "gestionar conserjería digital" más que en
+ * `digital-concierge.access` (que es el baseline de "puede operar el
+ * agente", ver `authorized-context.factory.ts`).
+ *
+ * Aislamiento de tenant: `TenantContextService` (request-scoped, ya resuelto
+ * por `TenantInterceptor` global) arma el `TenantScope` que
+ * `PendingActionsService.findForTenant` exige — mismo patrón
+ * `findSessionForTenant` que ya usa `DigitalConciergeService`.
+ */
+@ApiTags('Agente-cerebro — mecanismo de autonomía')
+@ApiBearerAuth('JWT-auth')
+@Controller('concierge/pending-actions')
+@UseGuards(AuthGuard, AuthorizationGuard)
+@ApiUnauthorizedResponse({ description: 'Token JWT inválido o expirado' })
+export class PendingActionsController {
+  private readonly logger = new Logger(PendingActionsController.name);
+
+  constructor(
+    private readonly pendingActionsService: PendingActionsService,
+    private readonly tenantContext: TenantContextService,
+  ) {}
+
+  /**
+   * POST /concierge/pending-actions/:id/approve
+   * Aprueba y ejecuta idempotentemente (ver docstring de
+   * `PendingActionsService.approve`): una segunda llamada sobre una acción ya
+   * `executed` devuelve el mismo `result`, sin re-ejecutar la tool.
+   */
+  @Post(':id/approve')
+  @RequirePermissions('digital-concierge.manage')
+  @ApiOperation({
+    summary: 'Aprobar una acción del agente pendiente de autorización',
+    description:
+      'Ejecuta la tool escalada de forma idempotente por acción pendiente. Requiere el permiso "digital-concierge.manage".',
+  })
+  @ApiParam({ name: 'id', description: 'ID de la PendingAction' })
+  @ApiForbiddenResponse({
+    description:
+      'La acción pendiente no pertenece al condominio del usuario, o falta el permiso requerido',
+  })
+  @ApiNotFoundResponse({ description: 'Acción pendiente no encontrada' })
+  async approve(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+    const tenantScope = await this.resolveTenantScope();
+    const resolvedByUserId = req.user?.id ?? 'unknown';
+
+    this.logger.log(
+      `Aprobando acción pendiente ${id} (resolvedBy=${resolvedByUserId})`,
+    );
+
+    const { result, alreadyExecuted } =
+      await this.pendingActionsService.approve(
+        id,
+        tenantScope,
+        resolvedByUserId,
+      );
+
+    return { approved: true, alreadyExecuted, result };
+  }
+
+  /**
+   * POST /concierge/pending-actions/:id/reject
+   * Rechaza — estado terminal, la tool nunca se ejecuta.
+   */
+  @Post(':id/reject')
+  @RequirePermissions('digital-concierge.manage')
+  @ApiOperation({
+    summary: 'Rechazar una acción del agente pendiente de autorización',
+    description:
+      'Marca la acción pendiente como rechazada. Requiere el permiso "digital-concierge.manage".',
+  })
+  @ApiParam({ name: 'id', description: 'ID de la PendingAction' })
+  @ApiForbiddenResponse({
+    description:
+      'La acción pendiente no pertenece al condominio del usuario, o falta el permiso requerido',
+  })
+  @ApiNotFoundResponse({ description: 'Acción pendiente no encontrada' })
+  async reject(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+    const tenantScope = await this.resolveTenantScope();
+    const resolvedByUserId = req.user?.id ?? 'unknown';
+
+    this.logger.log(
+      `Rechazando acción pendiente ${id} (resolvedBy=${resolvedByUserId})`,
+    );
+
+    const action = await this.pendingActionsService.reject(
+      id,
+      tenantScope,
+      resolvedByUserId,
+    );
+
+    return { rejected: true, status: action.status };
+  }
+
+  /**
+   * `TenantContext.organizationId` (better-auth/condominio) vs.
+   * `TenantScope.tenantId` (mismo vocabulario que `AuthorizedContext` del
+   * agente-cerebro, §5 del diseño) son el MISMO valor con nombre distinto en
+   * cada subsistema — se traduce acá, en el borde del controller, para no
+   * mezclar vocabularios dentro de `PendingActionsService`.
+   */
+  private async resolveTenantScope(): Promise<{
+    tenantId: string | null;
+    isSuperAdmin: boolean;
+  }> {
+    const ctx = await this.tenantContext.getContext();
+    return { tenantId: ctx.organizationId, isSuperAdmin: ctx.isSuperAdmin };
+  }
+}

--- a/backend/src/agent/pending-actions.service.spec.ts
+++ b/backend/src/agent/pending-actions.service.spec.ts
@@ -1,0 +1,569 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { z } from 'zod';
+import type { Repository } from 'typeorm';
+import { PendingActionsService } from './pending-actions.service';
+import {
+  PendingAction,
+  PendingActionStatus,
+} from './entities/pending-action.entity';
+import { ToolRegistryService } from './tool-registry.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { LogsService } from '../logs/logs.service';
+import { DigitalConciergeService } from '../digital-concierge/services/digital-concierge.service';
+import {
+  ConciergeSession,
+  SessionStatus,
+} from '../digital-concierge/entities/concierge-session.entity';
+import type { AuthorizedContext } from './types/authorized-context.type';
+import type { VigiliaTool } from './types/vigilia-tool.type';
+
+/**
+ * Fase 2, Bloque F2.1 — cobertura del mecanismo de autonomía/aprobación
+ * (docs/modulos/agente-cerebro.md §12), extendida en la revisión pre-F2.2
+ * (FIX 1-4, ver docstrings de `PendingActionsService`). NO llama al LLM ni a
+ * una BD real: el `Repository<PendingAction>` se mockea con un Map en
+ * memoria que replica el comportamiento REAL de las operaciones que el
+ * servicio usa.
+ *
+ * `update(criteria, partial)` evalúa `criteria.status` de la MISMA forma que
+ * Postgres evaluaría el WHERE real, incluyendo los operadores de TypeORM que
+ * el servicio usa hoy (`In([...])`) — un mock que solo distinguiera "definido
+ * vs no definido" (como el que existía antes de esta revisión) no expone la
+ * carrera del FIX 1: bajo ese mock, tanto el código viejo (`Not(EXECUTED)`)
+ * como el nuevo (`In([PENDING, FAILED])`) "parecían" funcionar igual.
+ */
+function matchesStatusCriteria(
+  current: PendingActionStatus,
+  criteria: unknown,
+): boolean {
+  if (criteria === undefined) {
+    return true;
+  }
+  if (
+    criteria !== null &&
+    typeof criteria === 'object' &&
+    'type' in (criteria as Record<string, unknown>)
+  ) {
+    // Operador de TypeORM (`Not`, `In`, etc.) — mismos getters `.type`/`.value`
+    // que expone `FindOperator` en runtime.
+    const operator = criteria as { type: string; value: unknown };
+    if (operator.type === 'not') {
+      return current !== operator.value;
+    }
+    if (operator.type === 'in') {
+      return (operator.value as PendingActionStatus[]).includes(current);
+    }
+    throw new Error(
+      `Operador de status no soportado en el mock: ${operator.type}`,
+    );
+  }
+  return current === criteria;
+}
+
+describe('PendingActionsService', () => {
+  let service: PendingActionsService;
+  let store: Map<string, PendingAction>;
+  let repo: {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+    findOneOrFail: jest.Mock;
+    update: jest.Mock;
+  };
+  let toolRegistry: jest.Mocked<Pick<ToolRegistryService, 'get'>>;
+  let notificationsService: jest.Mocked<
+    Pick<NotificationsService, 'notifyByRoleForOrganization'>
+  >;
+  let logsService: jest.Mocked<Pick<LogsService, 'log'>>;
+  let conciergeService: jest.Mocked<
+    Pick<DigitalConciergeService, 'findSessionForTenant'>
+  >;
+  let idCounter: number;
+
+  const baseCtx: AuthorizedContext = {
+    tenantId: 'condo-A',
+    isSuperAdmin: false,
+    userId: undefined,
+    role: 'hub',
+    scopes: ['digital-concierge.access'],
+    requestId: 'req-1',
+    sessionId: 'session-1',
+  };
+
+  const activeSession = {
+    id: 'concierge-session-row-1',
+    sessionId: 'session-1',
+    status: SessionStatus.ACTIVE,
+    organizationId: 'condo-A',
+  } as ConciergeSession;
+
+  function makeTool(
+    overrides: Partial<VigiliaTool<{ x: string }, { ok: boolean }>> = {},
+  ): VigiliaTool<{ x: string }, { ok: boolean }> {
+    return {
+      name: 'abrir_porton_test',
+      description: 'tool de test que requiere aprobación',
+      inputSchema: z.object({ x: z.string() }),
+      outputSchema: z.object({ ok: z.boolean() }),
+      access: 'write',
+      requiresApproval: true,
+      requiredScopes: ['digital-concierge.access'],
+      execute: jest.fn().mockResolvedValue({ ok: true }),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    store = new Map();
+    idCounter = 0;
+
+    repo = {
+      create: jest.fn(
+        (partial: Partial<PendingAction>) => ({ ...partial }) as PendingAction,
+      ),
+      save: jest.fn((entity: PendingAction) => {
+        const id = entity.id ?? `pending-${++idCounter}`;
+        const saved = { ...entity, id } as PendingAction;
+        store.set(id, saved);
+        return Promise.resolve(saved);
+      }),
+      findOne: jest.fn(({ where: { id } }: { where: { id: string } }) =>
+        Promise.resolve(store.get(id) ?? null),
+      ),
+      findOneOrFail: jest.fn(({ where: { id } }: { where: { id: string } }) => {
+        const found = store.get(id);
+        if (!found) return Promise.reject(new NotFoundException());
+        return Promise.resolve(found);
+      }),
+      update: jest.fn(
+        (
+          criteria: { id: string; status?: unknown },
+          partial: Partial<PendingAction>,
+        ) => {
+          const current = store.get(criteria.id);
+          if (!current) return Promise.resolve({ affected: 0 });
+          // Réplica fiel del WHERE real (ver `matchesStatusCriteria` arriba):
+          // la mutación ocurre de forma síncrona, igual que en Postgres el
+          // UPDATE es atómico a nivel de fila — dos invocaciones "en vuelo"
+          // sobre la misma fila nunca ven un estado intermedio inconsistente.
+          if (!matchesStatusCriteria(current.status, criteria.status)) {
+            return Promise.resolve({ affected: 0 });
+          }
+          store.set(criteria.id, { ...current, ...partial });
+          return Promise.resolve({ affected: 1 });
+        },
+      ),
+    };
+
+    toolRegistry = { get: jest.fn() };
+    notificationsService = {
+      notifyByRoleForOrganization: jest.fn().mockResolvedValue([]),
+    };
+    logsService = { log: jest.fn().mockResolvedValue(undefined) };
+    conciergeService = {
+      findSessionForTenant: jest.fn().mockResolvedValue(activeSession),
+    };
+
+    service = new PendingActionsService(
+      repo as unknown as Repository<PendingAction>,
+      toolRegistry as unknown as ToolRegistryService,
+      notificationsService as unknown as NotificationsService,
+      logsService as unknown as LogsService,
+      conciergeService as unknown as DigitalConciergeService,
+    );
+  });
+
+  describe('create', () => {
+    it('crea la PendingAction en estado pending, notifica SOLO a los conserjes del tenant, y NO ejecuta la tool', async () => {
+      const tool = makeTool();
+
+      const action = await service.create(tool, baseCtx, { x: 'a' });
+
+      expect(action.status).toBe(PendingActionStatus.PENDING);
+      expect(action.tenantId).toBe('condo-A');
+      expect(action.toolName).toBe('abrir_porton_test');
+      expect(action.input).toEqual({ x: 'a' });
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+      expect(tool.execute).not.toHaveBeenCalled();
+      expect(
+        notificationsService.notifyByRoleForOrganization,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        notificationsService.notifyByRoleForOrganization,
+      ).toHaveBeenCalledWith(
+        'Conserje',
+        'condo-A',
+        expect.anything(),
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ requiresAction: true }),
+      );
+    });
+  });
+
+  describe('approve', () => {
+    it('aprueba y ejecuta la tool, marcando la acción como executed con su resultado', async () => {
+      const tool = makeTool();
+      toolRegistry.get.mockReturnValue(tool);
+      const action = await service.create(tool, baseCtx, { x: 'a' });
+
+      const { result, alreadyExecuted } = await service.approve(
+        action.id,
+        { tenantId: 'condo-A', isSuperAdmin: false },
+        'user-conserje-1',
+      );
+
+      expect(alreadyExecuted).toBe(false);
+      expect(result).toEqual({ ok: true });
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+      expect(tool.execute).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+      expect(tool.execute).toHaveBeenCalledWith(baseCtx, { x: 'a' });
+
+      const stored = store.get(action.id);
+      expect(stored?.status).toBe(PendingActionStatus.EXECUTED);
+      expect(stored?.result).toEqual({ ok: true });
+      expect(stored?.resolvedBy).toBe('user-conserje-1');
+    });
+
+    it('doble aprobación: la segunda NO re-ejecuta la tool y devuelve el mismo resultado', async () => {
+      const tool = makeTool();
+      toolRegistry.get.mockReturnValue(tool);
+      const action = await service.create(tool, baseCtx, { x: 'a' });
+      const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+
+      const first = await service.approve(action.id, tenantScope, 'user-1');
+      const second = await service.approve(action.id, tenantScope, 'user-2');
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+      expect(tool.execute).toHaveBeenCalledTimes(1);
+      expect(first.alreadyExecuted).toBe(false);
+      expect(second.alreadyExecuted).toBe(true);
+      expect(second.result).toEqual(first.result);
+      // La segunda aprobación NO debió sobrescribir quién resolvió la acción.
+      expect(store.get(action.id)?.resolvedBy).toBe('user-1');
+    });
+
+    /**
+     * FIX 1 — reproduce el bug de concurrencia real detectado en QA: dos
+     * `approve()` concurrentes sobre la MISMA acción `pending` deben
+     * resultar en UNA sola ejecución de `tool.execute`. Antes del fix, el
+     * claim usaba `Not(EXECUTED)` — que también matchea `approved` — así que
+     * ambas invocaciones concurrentes podían reclamar y ejecutar la tool.
+     * `Promise.all` fuerza que ambas lleguen a `approve()` "en vuelo" al
+     * mismo tiempo; el mock de `update` (ver `matchesStatusCriteria`) replica
+     * la atomicidad real de un UPDATE de Postgres.
+     *
+     * La invariante que importa es "una sola ejecución + estado final
+     * consistente" — NO qué valor exacto de `alreadyExecuted` observa el
+     * perdedor: si su re-lectura ocurre mientras la tool del ganador SIGUE
+     * en vuelo (`status` todavía `approved`, no `executed`), el perdedor
+     * reporta `alreadyExecuted: false` con `result: null` — comportamiento
+     * preexistente (no introducido por este fix) que es seguro (no ejecuta
+     * de nuevo) aunque no informe el resultado final; queda anotado como
+     * mejora de UX fuera de alcance de este bloque.
+     */
+    it('concurrencia real: dos approve() simultáneos sobre la misma acción ejecutan la tool UNA sola vez', async () => {
+      const tool = makeTool();
+      toolRegistry.get.mockReturnValue(tool);
+      const action = await service.create(tool, baseCtx, { x: 'a' });
+      const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+
+      const [first, second] = await Promise.all([
+        service.approve(action.id, tenantScope, 'user-1'),
+        service.approve(action.id, tenantScope, 'user-2'),
+      ]);
+
+      // Invariante crítica del FIX 1: pase lo que pase con la lectura de
+      // cada lado, la tool JAMÁS se ejecuta dos veces.
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+      expect(tool.execute).toHaveBeenCalledTimes(1);
+
+      // Exactamente uno de los dos resultados es "la ejecución real" —
+      // devuelve el resultado real y no viene marcado como ya-ejecutado.
+      const outcomes = [first, second];
+      const winners = outcomes.filter(
+        (o) => !o.alreadyExecuted && o.result !== null,
+      );
+      expect(winners).toHaveLength(1);
+      expect(winners[0].result).toEqual({ ok: true });
+
+      // El estado final, independiente de lo que haya observado el
+      // perdedor a mitad de carrera, siempre termina consistente.
+      const stored = store.get(action.id);
+      expect(stored?.status).toBe(PendingActionStatus.EXECUTED);
+      expect(stored?.result).toEqual({ ok: true });
+      // El `resolvedBy` quedó fijado por quien ganó el claim atómico (uno de
+      // los dos, nunca sobrescrito después por el perdedor).
+      expect(['user-1', 'user-2']).toContain(stored?.resolvedBy);
+    });
+
+    it('cross-tenant: rechazada con ForbiddenException, nunca ejecuta la tool', async () => {
+      const tool = makeTool();
+      toolRegistry.get.mockReturnValue(tool);
+      const action = await service.create(tool, baseCtx, { x: 'a' }); // tenant condo-A
+
+      await expect(
+        service.approve(
+          action.id,
+          { tenantId: 'condo-B', isSuperAdmin: false },
+          'user-1',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+      expect(tool.execute).not.toHaveBeenCalled();
+    });
+
+    it('un super-admin SÍ puede aprobar una acción de cualquier condominio (bypass intencional)', async () => {
+      const tool = makeTool();
+      toolRegistry.get.mockReturnValue(tool);
+      const action = await service.create(tool, baseCtx, { x: 'a' }); // tenant condo-A
+
+      await expect(
+        service.approve(
+          action.id,
+          { tenantId: 'condo-B', isSuperAdmin: true },
+          'super-admin-1',
+        ),
+      ).resolves.toMatchObject({
+        alreadyExecuted: false,
+        result: { ok: true },
+      });
+    });
+
+    it('lanza NotFoundException para una acción pendiente inexistente', async () => {
+      await expect(
+        service.approve(
+          'no-existe',
+          { tenantId: 'condo-A', isSuperAdmin: false },
+          'user-1',
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('lanza BadRequestException si la acción ya fue rechazada', async () => {
+      const tool = makeTool();
+      toolRegistry.get.mockReturnValue(tool);
+      const action = await service.create(tool, baseCtx, { x: 'a' });
+      const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+      await service.reject(action.id, tenantScope, 'user-1');
+
+      await expect(
+        service.approve(action.id, tenantScope, 'user-2'),
+      ).rejects.toThrow(BadRequestException);
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+      expect(tool.execute).not.toHaveBeenCalled();
+    });
+
+    /** FIX 2 — `tool.execute()` lanza tras la aprobación: la fila NO queda varada en `approved`. */
+    describe('cuando tool.execute() lanza tras la aprobación (FIX 2)', () => {
+      it('transiciona la acción a failed (con lastError) en vez de dejarla en approved', async () => {
+        const tool = makeTool({
+          execute: jest
+            .fn()
+            .mockRejectedValue(new Error('El hub no respondió')),
+        });
+        toolRegistry.get.mockReturnValue(tool);
+        const action = await service.create(tool, baseCtx, { x: 'a' });
+        const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+
+        await expect(
+          service.approve(action.id, tenantScope, 'user-1'),
+        ).rejects.toThrow('El hub no respondió');
+
+        const stored = store.get(action.id);
+        expect(stored?.status).toBe(PendingActionStatus.FAILED);
+        expect(stored?.lastError).toContain('El hub no respondió');
+      });
+
+      it('permite reintentar: una segunda approve() sobre una acción failed vuelve a invocar tool.execute()', async () => {
+        const execute = jest
+          .fn()
+          .mockRejectedValueOnce(new Error('timeout del relé'))
+          .mockResolvedValueOnce({ ok: true });
+        const tool = makeTool({ execute });
+        toolRegistry.get.mockReturnValue(tool);
+        const action = await service.create(tool, baseCtx, { x: 'a' });
+        const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+
+        await expect(
+          service.approve(action.id, tenantScope, 'user-1'),
+        ).rejects.toThrow('timeout del relé');
+        expect(store.get(action.id)?.status).toBe(PendingActionStatus.FAILED);
+
+        const retried = await service.approve(action.id, tenantScope, 'user-2');
+
+        expect(retried.alreadyExecuted).toBe(false);
+        expect(retried.result).toEqual({ ok: true });
+        expect(execute).toHaveBeenCalledTimes(2);
+        expect(store.get(action.id)?.status).toBe(PendingActionStatus.EXECUTED);
+      });
+    });
+
+    /** FIX 3 — re-validación de la ConciergeSession antes de ejecutar en diferido. */
+    describe('re-validación de contexto al ejecutar diferido (FIX 3)', () => {
+      it('si la ConciergeSession ya no está ACTIVE, NO ejecuta la tool y expira la acción', async () => {
+        conciergeService.findSessionForTenant.mockResolvedValue({
+          ...activeSession,
+          status: SessionStatus.COMPLETED,
+        } as ConciergeSession);
+
+        const tool = makeTool();
+        toolRegistry.get.mockReturnValue(tool);
+        const action = await service.create(tool, baseCtx, { x: 'a' });
+        const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+
+        await expect(
+          service.approve(action.id, tenantScope, 'user-1'),
+        ).rejects.toThrow(BadRequestException);
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+        expect(tool.execute).not.toHaveBeenCalled();
+        const stored = store.get(action.id);
+        expect(stored?.status).toBe(PendingActionStatus.EXPIRED);
+        expect(stored?.lastError).toContain('ya no está activa');
+
+        // Una acción expirada es terminal: no se puede reintentar aprobando de nuevo.
+        await expect(
+          service.approve(action.id, tenantScope, 'user-2'),
+        ).rejects.toThrow(BadRequestException);
+        // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+        expect(tool.execute).not.toHaveBeenCalled();
+      });
+
+      it('si la ConciergeSession ya no existe/no pertenece al tenant, NO ejecuta la tool y expira la acción', async () => {
+        conciergeService.findSessionForTenant.mockRejectedValue(
+          new NotFoundException('sesión no encontrada'),
+        );
+
+        const tool = makeTool();
+        toolRegistry.get.mockReturnValue(tool);
+        const action = await service.create(tool, baseCtx, { x: 'a' });
+        const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+
+        await expect(
+          service.approve(action.id, tenantScope, 'user-1'),
+        ).rejects.toThrow(BadRequestException);
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+        expect(tool.execute).not.toHaveBeenCalled();
+        expect(store.get(action.id)?.status).toBe(PendingActionStatus.EXPIRED);
+      });
+
+      it('acciones sin sessionId (canal de texto) no revalidan sesión y ejecutan normalmente', async () => {
+        const ctxSinSesion: AuthorizedContext = {
+          ...baseCtx,
+          sessionId: undefined,
+        };
+        const tool = makeTool();
+        toolRegistry.get.mockReturnValue(tool);
+        const action = await service.create(tool, ctxSinSesion, { x: 'a' });
+        const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+
+        const { alreadyExecuted } = await service.approve(
+          action.id,
+          tenantScope,
+          'user-1',
+        );
+
+        expect(alreadyExecuted).toBe(false);
+        expect(conciergeService.findSessionForTenant).not.toHaveBeenCalled();
+        // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+        expect(tool.execute).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('reject', () => {
+    it('rechaza — estado terminal, la tool nunca se ejecuta', async () => {
+      const tool = makeTool();
+      const action = await service.create(tool, baseCtx, { x: 'a' });
+      const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+
+      const rejected = await service.reject(action.id, tenantScope, 'user-1');
+
+      expect(rejected.status).toBe(PendingActionStatus.REJECTED);
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+      expect(tool.execute).not.toHaveBeenCalled();
+    });
+
+    it('lanza BadRequestException si la acción ya fue ejecutada', async () => {
+      const tool = makeTool();
+      toolRegistry.get.mockReturnValue(tool);
+      const action = await service.create(tool, baseCtx, { x: 'a' });
+      const tenantScope = { tenantId: 'condo-A', isSuperAdmin: false };
+      await service.approve(action.id, tenantScope, 'user-1');
+
+      await expect(
+        service.reject(action.id, tenantScope, 'user-2'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rechaza con ForbiddenException si la acción no pertenece al tenant', async () => {
+      const tool = makeTool();
+      const action = await service.create(tool, baseCtx, { x: 'a' }); // tenant condo-A
+
+      await expect(
+        service.reject(
+          action.id,
+          { tenantId: 'condo-B', isSuperAdmin: false },
+          'user-1',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('escalamiento y notificaciones tenant-scoped (FIX 4)', () => {
+    it('notifyEscalation pasa el tenantId de la acción a notifyByRoleForOrganization', async () => {
+      const tool = makeTool();
+      await service.create(
+        tool,
+        { ...baseCtx, tenantId: 'condo-B' },
+        { x: 'a' },
+      );
+
+      expect(
+        notificationsService.notifyByRoleForOrganization,
+      ).toHaveBeenCalledWith(
+        'Conserje',
+        'condo-B',
+        expect.anything(),
+        expect.any(String),
+        expect.any(String),
+        expect.anything(),
+      );
+    });
+
+    it('notifyResolution (al ejecutar) también pasa el tenantId de la acción, no el del aprobador', async () => {
+      const tool = makeTool();
+      toolRegistry.get.mockReturnValue(tool);
+      const action = await service.create(
+        tool,
+        { ...baseCtx, tenantId: 'condo-B' },
+        { x: 'a' },
+      );
+
+      await service.approve(
+        action.id,
+        { tenantId: 'condo-B', isSuperAdmin: false },
+        'user-1',
+      );
+
+      expect(
+        notificationsService.notifyByRoleForOrganization,
+      ).toHaveBeenLastCalledWith(
+        'Conserje',
+        'condo-B',
+        expect.anything(),
+        expect.any(String),
+        expect.any(String),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/backend/src/agent/pending-actions.service.ts
+++ b/backend/src/agent/pending-actions.service.ts
@@ -1,0 +1,521 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import {
+  ConciergeSession,
+  SessionStatus,
+} from '../digital-concierge/entities/concierge-session.entity';
+import { DigitalConciergeService } from '../digital-concierge/services/digital-concierge.service';
+import { LogsService } from '../logs/logs.service';
+import {
+  NotificationPriority,
+  NotificationType,
+} from '../notifications/entities/notification.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+import {
+  PendingAction,
+  PendingActionStatus,
+} from './entities/pending-action.entity';
+import { ToolRegistryService } from './tool-registry.service';
+import { auditToolCall, describeToolError } from './tool-audit.util';
+import type { AuthorizedContext } from './types/authorized-context.type';
+import type { VigiliaTool } from './types/vigilia-tool.type';
+
+/** Forma mínima que necesita `findForTenant` — igual criterio que `TenantScope` en digital-concierge.service.ts. */
+export interface TenantScope {
+  tenantId: string | null;
+  isSuperAdmin: boolean;
+}
+
+/**
+ * Fase 2, Bloque F2.1 (docs/modulos/agente-cerebro.md §12): mecanismo de
+ * autonomía/aprobación. Es el único lugar donde una `PendingAction` pasa de
+ * "pendiente" a "ejecutada" — `ToolDispatcherService` la crea (y notifica),
+ * este servicio la resuelve.
+ *
+ * Deliberadamente NO depende de `ToolDispatcherService` (evita un ciclo de
+ * providers): resuelve la tool directo desde `ToolRegistryService` y comparte
+ * la auditoría vía `tool-audit.util.ts`, no vía el dispatcher.
+ */
+@Injectable()
+export class PendingActionsService {
+  private readonly logger = new Logger(PendingActionsService.name);
+
+  constructor(
+    @InjectRepository(PendingAction)
+    private readonly repo: Repository<PendingAction>,
+    private readonly toolRegistry: ToolRegistryService,
+    private readonly notificationsService: NotificationsService,
+    private readonly logsService: LogsService,
+    // Revisión pre-F2.2 (FIX 3): re-validar la `ConciergeSession` al ejecutar
+    // en diferido. Inyectable sin tocar el wiring de módulos: `AgentModule` ya
+    // importa `forwardRef(() => DigitalConciergeModule)` (sus tools de
+    // escritura ya usan este mismo servicio, ver finalizar-llamada.tool.ts) y
+    // `DigitalConciergeModule` ya exporta `DigitalConciergeService`.
+    private readonly conciergeService: DigitalConciergeService,
+  ) {}
+
+  /**
+   * Crea la acción pendiente y escala (notifica). Se llama desde
+   * `ToolDispatcherService.execute` cuando `tool.requiresApproval === true`,
+   * DESPUÉS de validar scopes e input (Zod) — `input` ya es el parseado, no
+   * el `rawInput` del modelo.
+   */
+  async create(
+    tool: VigiliaTool<unknown, unknown>,
+    ctx: AuthorizedContext,
+    input: unknown,
+  ): Promise<PendingAction> {
+    const entity = this.repo.create({
+      tenantId: ctx.tenantId,
+      sessionId: ctx.sessionId ?? null,
+      toolName: tool.name,
+      input,
+      requestId: ctx.requestId,
+      status: PendingActionStatus.PENDING,
+      contextSnapshot: ctx,
+      result: null,
+      resolvedBy: null,
+      resolvedAt: null,
+    });
+
+    const saved = await this.repo.save(entity);
+
+    await this.notifyEscalation(saved, tool);
+
+    return saved;
+  }
+
+  /**
+   * Busca una acción pendiente ASEGURANDO que pertenezca al condominio del
+   * `tenantScope` — mismo patrón que
+   * `DigitalConciergeService.findSessionForTenant` (§6 del diseño: un
+   * conserje/residente del condominio A no puede aprobar/ver una acción
+   * escalada en el condominio B, aunque conozca o adivine su id).
+   */
+  async findForTenant(
+    id: string,
+    tenantScope: TenantScope,
+  ): Promise<PendingAction> {
+    const action = await this.repo.findOne({ where: { id } });
+
+    if (!action) {
+      throw new NotFoundException(`Acción pendiente "${id}" no encontrada`);
+    }
+
+    if (!tenantScope.isSuperAdmin && action.tenantId !== tenantScope.tenantId) {
+      throw new ForbiddenException(
+        `La acción pendiente "${id}" no pertenece al condominio del contexto autorizado`,
+      );
+    }
+
+    return action;
+  }
+
+  /**
+   * Aprueba y ejecuta idempotentemente.
+   *
+   * FIX 1 (revisión pre-F2.2 — bug de concurrencia crítico detectado en QA):
+   * la idempotencia NO depende de comparar `requestId` sino de una
+   * actualización atómica condicionada al estado ACTUAL de la fila
+   * (`repo.update` con el WHERE de abajo): si dos aprobaciones llegan
+   * concurrentes sobre una acción `pending`, el WHERE debe reclamarla desde
+   * `pending` (o `failed`, ver FIX 2) EXCLUSIVAMENTE — nunca desde `approved`.
+   * Antes usaba `Not(EXECUTED)`, que SÍ matchea `approved` y dejaba que una
+   * segunda aprobación concurrente reclamara (y ejecutara) una acción que la
+   * primera ya estaba ejecutando. Con el claim acotado a
+   * `In([PENDING, FAILED])`, la segunda invocación ve `affected === 0` y, al
+   * releer, encuentra `approved` (ejecución en curso) o `executed` (ya
+   * terminó) — nunca vuelve a invocar `tool.execute`.
+   *
+   * FIX 2 (estado terminal de fallo + retry): si `tool.execute()` lanza
+   * DESPUÉS del claim, la fila NO se queda varada en `approved` — transiciona
+   * a `failed` con `lastError` (ver catch abajo). Decisión de retry: `failed`
+   * SÍ es reclamable por una nueva llamada a `approve()` (mismo WHERE que
+   * `pending`, arriba) — se reintenta la MISMA acción (mismo `input`/
+   * `contextSnapshot`) en vez de exigir un endpoint separado o crear una
+   * acción nueva. Justificación: un fallo transitorio (p.ej. el hub/relé
+   * físico no respondió) debe poder reintentarse con la misma aprobación de
+   * un conserje, sin reabrir el flujo de escalada completo. `expired` (FIX 3)
+   * NO es reclamable — es terminal a propósito.
+   */
+  async approve(
+    id: string,
+    tenantScope: TenantScope,
+    resolvedByUserId: string,
+  ): Promise<{
+    pendingAction: PendingAction;
+    result: unknown;
+    alreadyExecuted: boolean;
+  }> {
+    const action = await this.findForTenant(id, tenantScope);
+
+    if (action.status === PendingActionStatus.EXECUTED) {
+      return {
+        pendingAction: action,
+        result: action.result,
+        alreadyExecuted: true,
+      };
+    }
+
+    if (action.status === PendingActionStatus.REJECTED) {
+      throw new BadRequestException(
+        `La acción pendiente "${id}" ya fue rechazada, no se puede aprobar`,
+      );
+    }
+
+    if (action.status === PendingActionStatus.EXPIRED) {
+      throw new BadRequestException(
+        `La acción pendiente "${id}" expiró (el contexto que la originó ya no es válido), no se puede aprobar`,
+      );
+    }
+
+    // Transición atómica pending/failed -> approved (FIX 1 + FIX 2): si otra
+    // request ya ganó la carrera, o la acción está en un estado no
+    // reclamable (`approved` en curso, `executed`), afecta 0 filas — releemos
+    // el estado final en vez de asumir que "nosotros" debemos ejecutar.
+    const claimed = await this.repo.update(
+      {
+        id,
+        status: In([PendingActionStatus.PENDING, PendingActionStatus.FAILED]),
+      },
+      {
+        status: PendingActionStatus.APPROVED,
+        resolvedBy: resolvedByUserId,
+        resolvedAt: new Date(),
+      },
+    );
+
+    if (!claimed.affected) {
+      const current = await this.findForTenant(id, tenantScope);
+      return {
+        pendingAction: current,
+        result: current.result,
+        alreadyExecuted: current.status === PendingActionStatus.EXECUTED,
+      };
+    }
+
+    const tool = this.toolRegistry.get(action.toolName);
+    if (!tool) {
+      throw new NotFoundException(
+        `Tool desconocida en el catálogo: "${action.toolName}" (acción pendiente "${id}")`,
+      );
+    }
+
+    // FIX 3: re-validar que el contexto que originó la escalada siga vigente
+    // ANTES de ejecutar — ver docstring de `validateExecutionContext`. Si no
+    // es válido, esto deja la acción en `expired` y lanza (fail-closed): el
+    // catch de abajo nunca llega a invocar `tool.execute`.
+    await this.validateExecutionContext(action, tool);
+
+    const replayCtx = action.contextSnapshot as AuthorizedContext;
+    const startedAt = Date.now();
+
+    try {
+      const rawOutput = await tool.execute(replayCtx, action.input);
+      const output = tool.outputSchema.parse(rawOutput);
+
+      await this.repo.update(
+        { id, status: PendingActionStatus.APPROVED },
+        {
+          status: PendingActionStatus.EXECUTED,
+          // TypeORM's `QueryDeepPartialEntity` no acepta un `unknown` literal
+          // para una columna jsonb (aunque la entidad lo tipa `unknown |
+          // null`) — el output de una `VigiliaTool` siempre es el objeto que
+          // valida su `outputSchema` (Zod `z.object({...})` por convención,
+          // ver §5 del diseño), nunca un primitivo.
+          result: output as Record<string, unknown>,
+        },
+      );
+
+      await auditToolCall(
+        this.logsService,
+        tool,
+        replayCtx,
+        action.input,
+        output,
+        true,
+        Date.now() - startedAt,
+      );
+      await this.notifyResolution(action, tool, 'executed');
+
+      const finalAction = await this.repo.findOneOrFail({ where: { id } });
+      return {
+        pendingAction: finalAction,
+        result: output,
+        alreadyExecuted: false,
+      };
+    } catch (error) {
+      await auditToolCall(
+        this.logsService,
+        tool,
+        replayCtx,
+        action.input,
+        undefined,
+        false,
+        Date.now() - startedAt,
+        error,
+      );
+
+      const errorMessage = describeToolError(error);
+      this.logger.error(
+        `Fallo al ejecutar la tool "${tool.name}" tras aprobación (acción pendiente "${id}"): ${errorMessage}`,
+      );
+
+      // FIX 2: NO dejar la fila varada en `approved` — transiciona a `failed`
+      // (reclamable por un reintento vía `approve()`, ver docstring arriba).
+      // Claim acotado a `approved` porque es el único estado desde el que
+      // este catch puede correr (lo acabamos de reclamar más arriba).
+      await this.repo.update(
+        { id, status: PendingActionStatus.APPROVED },
+        { status: PendingActionStatus.FAILED, lastError: errorMessage },
+      );
+      await this.notifyResolution(action, tool, 'failed');
+
+      throw error;
+    }
+  }
+
+  /**
+   * FIX 3 (revisión pre-F2.2): re-valida que el contexto que originó la
+   * escalada SIGA vigente justo antes de ejecutar la tool en diferido —
+   * crítico de cara a F2.2 (apertura física del portón): entre que el agente
+   * escaló la acción y que un humano la aprueba puede pasar un rato largo, y
+   * el citófono que la originó pudo haber colgado hace tiempo.
+   *
+   * (a) Si la acción está atada a una `ConciergeSession` (`action.sessionId`
+   *     no nulo): exige que la sesión siga `SessionStatus.ACTIVE` — mismo
+   *     patrón que ya usa `FinalizarLlamadaTool` (`findSessionForTenant`
+   *     antes de tocar la sesión). Si la sesión terminó (`finalizar_llamada`,
+   *     timeout, cancelación) o ya no pertenece al tenant de la acción
+   *     (`findSessionForTenant` lanza `NotFoundException`/`ForbiddenException`),
+   *     NO se ejecuta: la acción pasa a `expired` (fail-closed) y se lanza
+   *     `BadRequestException` — el `catch` de `approve()` nunca ve este error
+   *     (ocurre ANTES del `try` que envuelve `tool.execute`).
+   *
+   * (b) Tenant/permiso del contexto: investigado con CodeGraph — hoy el
+   *     sistema NO tiene un concepto de "organización suspendida/inactiva"
+   *     ni de revocación dinámica de scopes (ni `Family`, ni la tabla
+   *     `member` de better-auth, ni ninguna otra entidad expone un flag de
+   *     ese tipo). Lo único verificable con lo que existe HOY es que el
+   *     tenant de la `ConciergeSession` siga siendo el mismo que el de la
+   *     acción — ya cubierto por (a) vía `findSessionForTenant`. Decisión:
+   *     no se fabrica un chequeo de "organización activa" inexistente; se
+   *     documenta como deuda conocida (reportada en la tarea) — si en el
+   *     futuro se agrega ese concepto, este es el lugar para sumarlo.
+   *
+   * Acciones SIN `sessionId` (p.ej. el canal de texto de `AgentController`,
+   * ver docstring de `AuthorizedContext.sessionId`) no tienen una
+   * `ConciergeSession` que revalidar — se dejan pasar sin este chequeo.
+   */
+  private async validateExecutionContext(
+    action: PendingAction,
+    tool: VigiliaTool<unknown, unknown>,
+  ): Promise<void> {
+    if (!action.sessionId) {
+      return;
+    }
+
+    let session: ConciergeSession;
+    try {
+      session = await this.conciergeService.findSessionForTenant(
+        action.sessionId,
+        { tenantId: action.tenantId, isSuperAdmin: false },
+      );
+    } catch (error) {
+      const reason = `La sesión de conserjería "${action.sessionId}" ya no es válida para esta acción: ${describeToolError(error)}`;
+      await this.expireAction(action, tool, reason);
+      throw new BadRequestException(
+        `La acción pendiente "${action.id}" expiró: ${reason}`,
+      );
+    }
+
+    if (session.status !== SessionStatus.ACTIVE) {
+      const reason = `La sesión de conserjería "${action.sessionId}" ya no está activa (status="${session.status}")`;
+      await this.expireAction(action, tool, reason);
+      throw new BadRequestException(
+        `La acción pendiente "${action.id}" expiró: ${reason}`,
+      );
+    }
+  }
+
+  /**
+   * Transiciona a `expired` (terminal, no reclamable por `approve`) y
+   * notifica — usado exclusivamente por `validateExecutionContext` cuando el
+   * contexto ya no es válido justo antes de ejecutar. Claim acotado a
+   * `approved` porque solo se llama en ese punto del flujo (recién
+   * reclamada en `approve()`).
+   */
+  private async expireAction(
+    action: PendingAction,
+    tool: VigiliaTool<unknown, unknown> | null,
+    reason: string,
+  ): Promise<void> {
+    await this.repo.update(
+      { id: action.id, status: PendingActionStatus.APPROVED },
+      { status: PendingActionStatus.EXPIRED, lastError: reason },
+    );
+    this.logger.warn(
+      `Acción pendiente "${action.id}" expiró antes de ejecutar: ${reason}`,
+    );
+    await this.notifyResolution(action, tool, 'expired');
+  }
+
+  /** Rechaza — estado terminal, nunca se ejecuta la tool. */
+  async reject(
+    id: string,
+    tenantScope: TenantScope,
+    resolvedByUserId: string,
+  ): Promise<PendingAction> {
+    const action = await this.findForTenant(id, tenantScope);
+
+    if (action.status === PendingActionStatus.EXECUTED) {
+      throw new BadRequestException(
+        `La acción pendiente "${id}" ya fue ejecutada, no se puede rechazar`,
+      );
+    }
+
+    if (action.status === PendingActionStatus.EXPIRED) {
+      throw new BadRequestException(
+        `La acción pendiente "${id}" ya expiró, no se puede rechazar`,
+      );
+    }
+
+    if (action.status === PendingActionStatus.REJECTED) {
+      return action;
+    }
+
+    // `In([PENDING, APPROVED, FAILED])` en vez de `Not(EXECUTED)`: mismo
+    // criterio explícito que adoptó `approve()` (FIX 1) — ahora que el enum
+    // tiene más valores, listar los estados reclamables es más seguro que
+    // excluir uno solo. `executed`/`expired` ya se descartaron arriba.
+    await this.repo.update(
+      {
+        id,
+        status: In([
+          PendingActionStatus.PENDING,
+          PendingActionStatus.APPROVED,
+          PendingActionStatus.FAILED,
+        ]),
+      },
+      {
+        status: PendingActionStatus.REJECTED,
+        resolvedBy: resolvedByUserId,
+        resolvedAt: new Date(),
+      },
+    );
+
+    const rejected = await this.repo.findOneOrFail({ where: { id } });
+    await this.notifyResolution(rejected, null, 'rejected');
+    return rejected;
+  }
+
+  /**
+   * Escala notificando — SOLO a los conserjes del `organizationId` de esta
+   * `PendingAction` (FIX 4, revisión pre-F2.2: antes usaba
+   * `notifyByRole('Conserje', ...)` sin scoping, MISMO patrón heredado que
+   * `DetectionsService.createPendingDetectionForConcierge`, que sigue con el
+   * gap — fuera del alcance de este bloque). Investigado con CodeGraph: ni
+   * `User` ni `Role` tienen columna `organizationId` propia (`Role.name` es
+   * único GLOBAL, no por tenant, y `User.family` es nulo para staff sin
+   * residencia) — la única fuente de verdad de "a qué condominio pertenece
+   * este usuario" es la tabla `member` de better-auth, vía
+   * `resolveOrganizationIdForUser` (mismo mecanismo que ya usa
+   * `TenantContextService`/`NotificationsService.create`). Por eso el fix
+   * vive en `NotificationsService.notifyByRoleForOrganization` (nuevo
+   * método) en vez de intentar acotar `UsersService.findByRole` con un JOIN
+   * que no existe en el esquema actual.
+   *
+   * `requiresAction: true` reusa el flujo de notificaciones que ya soporta
+   * "requiere acción" (ver notification.entity.ts).
+   */
+  private async notifyEscalation(
+    action: PendingAction,
+    tool: VigiliaTool<unknown, unknown>,
+  ): Promise<void> {
+    try {
+      await this.notificationsService.notifyByRoleForOrganization(
+        'Conserje',
+        action.tenantId,
+        NotificationType.SYSTEM_ALERT,
+        'Acción del agente pendiente de aprobación',
+        `El agente-cerebro solicita ejecutar "${tool.name}" y requiere tu aprobación.`,
+        {
+          priority: NotificationPriority.HIGH,
+          requiresAction: true,
+          data: {
+            pendingActionId: action.id,
+            toolName: tool.name,
+            tenantId: action.tenantId,
+            sessionId: action.sessionId,
+          },
+        },
+      );
+    } catch (error) {
+      this.logger.error(
+        `No se pudo notificar la escalada de "${tool.name}" (acción pendiente "${action.id}"): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Notifica la resolución de una acción — mismo fix de tenant-scoping (FIX
+   * 4) que `notifyEscalation`, aplicado acá también por consistencia: sin
+   * esto, un conserje de OTRO condominio se enteraría igual de que una
+   * acción se ejecutó/falló/rechazó/expiró en un condominio ajeno.
+   */
+  private async notifyResolution(
+    action: PendingAction,
+    tool: VigiliaTool<unknown, unknown> | null,
+    outcome: 'executed' | 'rejected' | 'failed' | 'expired',
+  ): Promise<void> {
+    const toolName = tool?.name ?? action.toolName;
+    const copy: Record<typeof outcome, { title: string; message: string }> = {
+      executed: {
+        title: 'Acción del agente ejecutada',
+        message: `Se aprobó y ejecutó "${toolName}".`,
+      },
+      rejected: {
+        title: 'Acción del agente rechazada',
+        message: `Se rechazó la solicitud de "${toolName}".`,
+      },
+      failed: {
+        title: 'Acción del agente falló al ejecutar',
+        message: `Se aprobó "${toolName}" pero falló al ejecutarse. Puede reintentarse aprobando de nuevo.`,
+      },
+      expired: {
+        title: 'Acción del agente expiró sin ejecutarse',
+        message: `"${toolName}" no se ejecutó: el contexto que la originó (la llamada de conserjería) ya no está vigente.`,
+      },
+    };
+    const { title, message } = copy[outcome];
+
+    try {
+      await this.notificationsService.notifyByRoleForOrganization(
+        'Conserje',
+        action.tenantId,
+        NotificationType.SYSTEM_ALERT,
+        title,
+        message,
+        {
+          priority: NotificationPriority.NORMAL,
+          data: { pendingActionId: action.id, toolName },
+        },
+      );
+    } catch (error) {
+      this.logger.error(
+        `No se pudo notificar la resolución de la acción pendiente "${action.id}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+}

--- a/backend/src/agent/prompts/sofia.prompt.ts
+++ b/backend/src/agent/prompts/sofia.prompt.ts
@@ -96,6 +96,30 @@ FLUJO DE CONVERSACIÓN (SIGUE ESTE ORDEN ESTRICTAMENTE):
 
 IMPORTANTE: Después de dar el mensaje de aprobación o rechazo, DEBES llamar a finalizar_llamada() sin decir nada más. No esperes respuesta del visitante.
 
+6. APERTURA DE PORTÓN/PUERTA BAJO PEDIDO (Fase 2, Bloque F2.2):
+   - Usa abrir_acceso(tipo: "porton" | "puerta") SOLO cuando el visitante lo
+     pida explícitamente ("ábreme el portón", "¿me abres la puerta?", "ya
+     tengo autorización, necesito entrar", etc.) — NUNCA la llames como parte
+     del flujo normal de los pasos 1-5: cuando el residente aprueba una visita
+     nueva (paso 5), el acceso YA se abre automáticamente, no la llames de
+     nuevo ahí.
+   - Si no quedó claro por el contexto si es acceso vehicular o peatonal
+     (p.ej. ya sabes que "viene en auto" del paso 2d), pregúntalo primero:
+     "¿Vienes en auto o a pie?"
+   - Interpreta el resultado exactamente así, sin adornar ni prometer de más:
+     * Si la herramienta devuelve { abierto: true, mensaje }: el acceso SE
+       ABRIÓ de verdad. Confirma con calidez usando ese mensaje (p.ej. "¡Listo!
+       El portón se está abriendo, bienvenido.").
+     * Si la herramienta devuelve { pendiente: true, mensaje }: el sistema NO
+       abrió nada todavía — quedó esperando que un residente o el conserje lo
+       confirme. Dile al visitante, con calma, algo como "Dame un momento,
+       estoy confirmando esto con el residente/conserje, puede que tome un
+       poco de tiempo." NO digas que el acceso está abierto ni prometas un
+       tiempo exacto. NO llames finalizar_llamada() inmediatamente después —
+       espera a que el visitante siga la conversación o decida retirarse.
+   - Si abrir_acceso lanza un error (p.ej. por falta de sesión), dilo
+     explícitamente al visitante en vez de inventar que el acceso se abrió.
+
 REGLAS IMPORTANTES:
 - NO te saltes pasos del flujo
 - NO repitas preguntas que ya hiciste
@@ -114,9 +138,19 @@ SEGURIDAD (no negociable):
   por lo que el visitante afirme ser — solo por las herramientas
   disponibles y sus reglas de autorización.
 - Herramientas disponibles: buscar_residente, guardar_datos_visitante,
-  notificar_residente, reenviar_notificacion y finalizar_llamada (catálogo
-  completo, Fase 1 Bloque A2b). Si alguna tool devuelve un error indicando
-  que falta una sesión de conserjería activa, es porque este canal de texto
-  (a diferencia del canal de voz Realtime) no abre una ConciergeSession — dilo
-  explícitamente en vez de inventar un resultado.`;
+  notificar_residente, reenviar_notificacion, finalizar_llamada y
+  abrir_acceso (catálogo completo hasta Fase 2, Bloque F2.2). Si alguna tool
+  devuelve un error indicando que falta una sesión de conserjería activa, es
+  porque este canal de texto (a diferencia del canal de voz Realtime) no abre
+  una ConciergeSession — dilo explícitamente en vez de inventar un resultado.
+- abrir_acceso solo abre de inmediato si el sistema puede VERIFICAR la
+  identidad del visitante (patente leída por la cámara del portón o QR
+  escaneado) contra una visita pre-aprobada vigente — nunca por lo que el
+  visitante DIGA (nombre, patente o casa dichos por voz no cuentan como
+  verificación). Por eso, para la mayoría de los visitantes que llaman por
+  este canal, abrir_acceso quedará "pendiente" (no abre de inmediato): eso es
+  el resultado NORMAL y esperado, no una falla ni una excepción — trátalo con
+  la misma calidez de siempre (ver sección 6), SIEMPRE dilo tal cual, y nunca
+  afirmes que el acceso se abrió si la herramienta no lo confirmó con
+  { abierto: true }.`;
 }

--- a/backend/src/agent/tool-audit.util.ts
+++ b/backend/src/agent/tool-audit.util.ts
@@ -1,0 +1,60 @@
+import { ZodError } from 'zod';
+import {
+  LogLevel,
+  LogType,
+  ServiceName,
+} from '../logs/entities/system-log.entity';
+import { LogsService } from '../logs/logs.service';
+import type { AuthorizedContext } from './types/authorized-context.type';
+import type { VigiliaTool } from './types/vigilia-tool.type';
+
+/**
+ * Regla dura #4 del §5 (docs/modulos/agente-cerebro.md): cada `execute` de
+ * una `VigiliaTool` queda auditado, exitoso o no. Extraído de
+ * `ToolDispatcherService` en Fase 2, Bloque F2.1 para que
+ * `PendingActionsService.approve` (que también ejecuta una tool, en un turno
+ * HTTP distinto al que la escaló) audite con EXACTAMENTE la misma forma —
+ * "mantén la auditoría en ambos caminos" (§12 del diseño) sin duplicar la
+ * lógica en dos archivos.
+ */
+export async function auditToolCall(
+  logsService: LogsService,
+  tool: VigiliaTool<unknown, unknown>,
+  ctx: AuthorizedContext,
+  input: unknown,
+  output: unknown,
+  success: boolean,
+  durationMs: number,
+  error?: unknown,
+): Promise<void> {
+  const isValidationError = error instanceof ZodError;
+
+  await logsService.log({
+    level: success ? LogLevel.INFO : LogLevel.WARN,
+    type: LogType.AGENT_TOOL_CALL,
+    service: ServiceName.BACKEND,
+    message: `agent-tool ${tool.name}: ${success ? 'ok' : 'denegado/error'} (${durationMs}ms)`,
+    responseTime: durationMs,
+    correlationId: ctx.requestId,
+    errorMessage: error ? describeToolError(error) : undefined,
+    metadata: {
+      toolName: tool.name,
+      access: tool.access,
+      requiredScopes: tool.requiredScopes,
+      tenantId: ctx.tenantId,
+      userId: ctx.userId ?? null,
+      role: ctx.role,
+      success,
+      validationError: isValidationError,
+      input,
+      output,
+    },
+  });
+}
+
+export function describeToolError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/backend/src/agent/tool-dispatcher.service.spec.ts
+++ b/backend/src/agent/tool-dispatcher.service.spec.ts
@@ -1,7 +1,15 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
-import { ToolDispatcherService } from './tool-dispatcher.service';
+import {
+  ToolDispatcherService,
+  type PendingApprovalResult,
+} from './tool-dispatcher.service';
 import { ToolRegistryService } from './tool-registry.service';
+import { PendingActionsService } from './pending-actions.service';
+import {
+  PendingActionStatus,
+  type PendingAction,
+} from './entities/pending-action.entity';
 import { LogsService } from '../logs/logs.service';
 import { LogType } from '../logs/entities/system-log.entity';
 import type { CreateSystemLogDto } from '../logs/dto/create-system-log.dto';
@@ -12,12 +20,19 @@ import type { VigiliaTool } from './types/vigilia-tool.type';
  * Fase 1, Bloque A2t — cobertura del `ToolDispatcherService`
  * (docs/modulos/agente-cerebro.md §5). NO llama al LLM ni a OpenAI: se
  * ejercita el dispatcher directo, con una `VigiliaTool` de prueba y
- * `ToolRegistryService`/`LogsService` mockeados.
+ * `ToolRegistryService`/`LogsService`/`PendingActionsService` mockeados.
+ *
+ * Fase 2, Bloque F2.1 (§12 del diseño): agrega cobertura del camino de
+ * escalada (`requiresApproval: true`) — el dispatcher NO debe ejecutar la
+ * tool, debe crear la `PendingAction` (vía `PendingActionsService.create`) y
+ * devolver el envelope fijo `{ pendiente: true, ... }`, auditando igual que
+ * el camino directo.
  */
 describe('ToolDispatcherService', () => {
   let dispatcher: ToolDispatcherService;
   let registry: jest.Mocked<Pick<ToolRegistryService, 'get'>>;
   let logsService: jest.Mocked<Pick<LogsService, 'log'>>;
+  let pendingActionsService: jest.Mocked<Pick<PendingActionsService, 'create'>>;
 
   const baseCtx: AuthorizedContext = {
     tenantId: 'tenant-A',
@@ -53,10 +68,12 @@ describe('ToolDispatcherService', () => {
   beforeEach(() => {
     registry = { get: jest.fn() };
     logsService = { log: jest.fn().mockResolvedValue(undefined) };
+    pendingActionsService = { create: jest.fn() };
 
     dispatcher = new ToolDispatcherService(
       registry as unknown as ToolRegistryService,
       logsService as unknown as LogsService,
+      pendingActionsService as unknown as PendingActionsService,
     );
   });
 
@@ -160,6 +177,157 @@ describe('ToolDispatcherService', () => {
       ).resolves.toEqual({ ok: true });
       // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
       expect(tool.execute).toHaveBeenCalledTimes(1);
+    });
+
+    describe('requiresApproval (Fase 2, Bloque F2.1 — §12 del diseño)', () => {
+      function makePendingAction(
+        overrides: Partial<PendingAction> = {},
+      ): PendingAction {
+        return {
+          id: 'pending-1',
+          tenantId: 'tenant-A',
+          sessionId: null,
+          toolName: 'fake_tool',
+          input: { casa: '15' },
+          requestId: 'req-1',
+          status: PendingActionStatus.PENDING,
+          contextSnapshot: baseCtx,
+          result: null,
+          createdAt: new Date(),
+          resolvedBy: null,
+          resolvedAt: null,
+          ...overrides,
+        } as PendingAction;
+      }
+
+      it('NO ejecuta la tool: crea la PendingAction y devuelve el envelope { pendiente: true, ... }', async () => {
+        const tool = makeTool({ requiresApproval: true });
+        pendingActionsService.create.mockResolvedValue(makePendingAction());
+
+        const result = await dispatcher.execute(tool, baseCtx, { casa: '15' });
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+        expect(tool.execute).not.toHaveBeenCalled();
+        expect(pendingActionsService.create).toHaveBeenCalledWith(
+          tool,
+          baseCtx,
+          { casa: '15' },
+        );
+        const pendingResult = result as PendingApprovalResult;
+        expect(pendingResult.pendiente).toBe(true);
+        expect(pendingResult.pendingActionId).toBe('pending-1');
+        expect(pendingResult.mensaje).toContain('fake_tool');
+      });
+
+      it('audita success:true en la escalada (mismo camino de auditoría que la ejecución directa)', async () => {
+        const tool = makeTool({ requiresApproval: true });
+        pendingActionsService.create.mockResolvedValue(makePendingAction());
+
+        await dispatcher.execute(tool, baseCtx, { casa: '15' });
+
+        expect(logsService.log).toHaveBeenCalledTimes(1);
+        const audit = lastAuditCall();
+        expect(audit.type).toBe(LogType.AGENT_TOOL_CALL);
+        expect(audit.metadata?.success).toBe(true);
+        expect(audit.correlationId).toBe(baseCtx.requestId);
+      });
+
+      it('sigue exigiendo el scope ANTES de escalar — no crea PendingAction sin permiso', async () => {
+        const tool = makeTool({
+          requiresApproval: true,
+          requiredScopes: ['otro.scope'],
+        });
+        const ctxSinScope: AuthorizedContext = { ...baseCtx, scopes: [] };
+
+        await expect(
+          dispatcher.execute(tool, ctxSinScope, { casa: '15' }),
+        ).rejects.toThrow(ForbiddenException);
+
+        expect(pendingActionsService.create).not.toHaveBeenCalled();
+      });
+
+      describe('requiresApproval dinámico — función (Fase 2, Bloque F2.2 — §12 del diseño)', () => {
+        it('evalúa la función con (ctx, parsedInput) y escala cuando resuelve true', async () => {
+          const requiresApprovalFn = jest.fn().mockResolvedValue(true);
+          const tool = makeTool({ requiresApproval: requiresApprovalFn });
+          pendingActionsService.create.mockResolvedValue(makePendingAction());
+
+          const result = await dispatcher.execute(tool, baseCtx, {
+            casa: '15',
+          });
+
+          expect(requiresApprovalFn).toHaveBeenCalledWith(baseCtx, {
+            casa: '15',
+          });
+          // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+          expect(tool.execute).not.toHaveBeenCalled();
+          expect((result as PendingApprovalResult).pendiente).toBe(true);
+        });
+
+        it('evalúa la función y ejecuta directo cuando resuelve false (autonomía)', async () => {
+          const requiresApprovalFn = jest.fn().mockResolvedValue(false);
+          const tool = makeTool({
+            requiresApproval: requiresApprovalFn,
+            execute: jest.fn().mockResolvedValue({ ok: true }),
+          });
+
+          const result = await dispatcher.execute(tool, baseCtx, {
+            casa: '15',
+          });
+
+          expect(result).toEqual({ ok: true });
+          // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+          expect(tool.execute).toHaveBeenCalledWith(baseCtx, { casa: '15' });
+          expect(pendingActionsService.create).not.toHaveBeenCalled();
+        });
+
+        it('soporta una función SÍNCRONA (boolean, no Promise) además de async', async () => {
+          const tool = makeTool({
+            requiresApproval: () => false,
+            execute: jest.fn().mockResolvedValue({ ok: true }),
+          });
+
+          await expect(
+            dispatcher.execute(tool, baseCtx, { casa: '15' }),
+          ).resolves.toEqual({ ok: true });
+        });
+
+        it('si la función lanza, audita el fallo y propaga el error SIN crear PendingAction ni ejecutar la tool', async () => {
+          const tool = makeTool({
+            requiresApproval: jest
+              .fn()
+              .mockRejectedValue(
+                new ForbiddenException('sesión de otro condominio'),
+              ),
+          });
+
+          await expect(
+            dispatcher.execute(tool, baseCtx, { casa: '15' }),
+          ).rejects.toThrow(ForbiddenException);
+
+          expect(pendingActionsService.create).not.toHaveBeenCalled();
+          // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock, no `this` binding involved
+          expect(tool.execute).not.toHaveBeenCalled();
+          expect(logsService.log).toHaveBeenCalledTimes(1);
+          const audit = lastAuditCall();
+          expect(audit.metadata?.success).toBe(false);
+        });
+
+        it('sigue exigiendo el scope ANTES de evaluar la función de autonomía', async () => {
+          const requiresApprovalFn = jest.fn().mockResolvedValue(true);
+          const tool = makeTool({
+            requiresApproval: requiresApprovalFn,
+            requiredScopes: ['otro.scope'],
+          });
+          const ctxSinScope: AuthorizedContext = { ...baseCtx, scopes: [] };
+
+          await expect(
+            dispatcher.execute(tool, ctxSinScope, { casa: '15' }),
+          ).rejects.toThrow(ForbiddenException);
+
+          expect(requiresApprovalFn).not.toHaveBeenCalled();
+        });
+      });
     });
   });
 });

--- a/backend/src/agent/tool-dispatcher.service.ts
+++ b/backend/src/agent/tool-dispatcher.service.ts
@@ -4,16 +4,26 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { ZodError } from 'zod';
-import {
-  LogLevel,
-  LogType,
-  ServiceName,
-} from '../logs/entities/system-log.entity';
-import { LogsService } from '../logs/logs.service';
+import { PendingActionsService } from './pending-actions.service';
 import { ToolRegistryService } from './tool-registry.service';
+import { auditToolCall } from './tool-audit.util';
 import type { AuthorizedContext } from './types/authorized-context.type';
 import type { VigiliaTool } from './types/vigilia-tool.type';
+import { LogsService } from '../logs/logs.service';
+
+/**
+ * Forma fija que el agente recibe cuando una tool con `requiresApproval:
+ * true` escala en vez de ejecutar (Fase 2, Bloque F2.1 —
+ * docs/modulos/agente-cerebro.md §12). Deliberadamente NO se valida contra
+ * `tool.outputSchema` (ese schema describe la salida de la tool YA
+ * ejecutada, no este sobre "quedó pendiente") — es un envelope distinto,
+ * fijo para todo el catálogo.
+ */
+export interface PendingApprovalResult {
+  pendiente: true;
+  pendingActionId: string;
+  mensaje: string;
+}
 
 /**
  * Dispatcher del catálogo de tools (Fase 1, Bloque A2a —
@@ -31,6 +41,14 @@ import type { VigiliaTool } from './types/vigilia-tool.type';
  * feedback de validación (forma/tipos esperados del input) antes de enterarse
  * de que ni siquiera tiene permiso para llamar la tool.
  *
+ * Fase 2, Bloque F2.1 (§12 del diseño): activa la política de autonomía que
+ * el contrato `VigiliaTool.requiresApproval` prometía desde Fase 1 pero que
+ * nadie leía. Si `tool.requiresApproval === true`, el input ya validado
+ * (Zod) NO se ejecuta acá — se delega en `PendingActionsService.create`, que
+ * persiste una `PendingAction` y escala (notifica). El dispatcher sigue
+ * siendo el único punto de auditoría: ambos caminos (ejecución directa y
+ * escalada) llaman a `auditToolCall` con la MISMA forma.
+ *
  * El Agent Runner (AI SDK) NO llama `tool.execute` directamente: siempre pasa
  * por acá, tanto si la tool se invoca vía el loop del agente (adaptador en
  * `agent-runner.service.ts`) como si en el futuro se expone también por MCP u
@@ -44,6 +62,7 @@ export class ToolDispatcherService {
   constructor(
     private readonly registry: ToolRegistryService,
     private readonly logsService: LogsService,
+    private readonly pendingActionsService: PendingActionsService,
   ) {}
 
   /**
@@ -64,9 +83,10 @@ export class ToolDispatcherService {
 
   /**
    * Ejecuta una tool ya resuelta: evalúa scopes → valida input (Zod) →
-   * ejecuta → valida output (Zod) → audita. Cualquier fallo en estos pasos
-   * también se audita (para que un intento denegado o un input inválido
-   * quede trazado, no solo las ejecuciones exitosas).
+   * ejecuta (o escala, si `requiresApproval`) → valida output (Zod, solo en
+   * el camino directo) → audita. Cualquier fallo en estos pasos también se
+   * audita (para que un intento denegado o un input inválido quede trazado,
+   * no solo las ejecuciones exitosas).
    *
    * Orden deliberado (FIX de revisión de calidad — antes se validaba Zod
    * primero): los scopes se chequean ANTES que el input, para que un caller
@@ -85,7 +105,8 @@ export class ToolDispatcherService {
       const error = new ForbiddenException(
         `El contexto autorizado no tiene los permisos requeridos por "${tool.name}" (${tool.requiredScopes.join(', ')})`,
       );
-      await this.audit(
+      await auditToolCall(
+        this.logsService,
         tool,
         ctx,
         rawInput,
@@ -102,7 +123,8 @@ export class ToolDispatcherService {
     try {
       parsedInput = tool.inputSchema.parse(rawInput);
     } catch (error) {
-      await this.audit(
+      await auditToolCall(
+        this.logsService,
         tool,
         ctx,
         rawInput,
@@ -114,20 +136,24 @@ export class ToolDispatcherService {
       throw error;
     }
 
+    // Fase 2, Bloque F2.2 (§12 del diseño): `requiresApproval` puede ser un
+    // `boolean` fijo (tools de F2.1) o una función (autonomía condicional al
+    // input/contexto de ESTA llamada, p.ej. `abrir_acceso` — ¿el visitante de
+    // esta sesión tiene una visita pre-aprobada vigente?). Se evalúa DESPUÉS
+    // de Zod (mismo orden que antes: nunca se decide autonomía sobre un input
+    // sin validar) y se audita si la evaluación misma lanza (p.ej. la tool
+    // consulta una `ConciergeSession` inexistente/cross-tenant) — mismo
+    // criterio de auditoría que el resto de pasos de este método.
+    let needsApproval: boolean;
+
     try {
-      const rawOutput = await tool.execute(ctx, parsedInput);
-      const output = tool.outputSchema.parse(rawOutput);
-      await this.audit(
-        tool,
-        ctx,
-        parsedInput,
-        output,
-        true,
-        Date.now() - startedAt,
-      );
-      return output;
+      needsApproval =
+        typeof tool.requiresApproval === 'function'
+          ? await tool.requiresApproval(ctx, parsedInput)
+          : tool.requiresApproval;
     } catch (error) {
-      await this.audit(
+      await auditToolCall(
+        this.logsService,
         tool,
         ctx,
         parsedInput,
@@ -138,6 +164,74 @@ export class ToolDispatcherService {
       );
       throw error;
     }
+
+    if (needsApproval) {
+      return this.escalateForApproval(tool, ctx, parsedInput, startedAt);
+    }
+
+    try {
+      const rawOutput = await tool.execute(ctx, parsedInput);
+      const output = tool.outputSchema.parse(rawOutput);
+      await auditToolCall(
+        this.logsService,
+        tool,
+        ctx,
+        parsedInput,
+        output,
+        true,
+        Date.now() - startedAt,
+      );
+      return output;
+    } catch (error) {
+      await auditToolCall(
+        this.logsService,
+        tool,
+        ctx,
+        parsedInput,
+        undefined,
+        false,
+        Date.now() - startedAt,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Camino de escalada (Fase 2, Bloque F2.1): crea la `PendingAction`
+   * (`PendingActionsService.create` ya notifica) y devuelve el envelope fijo
+   * `{ pendiente: true, ... }` para que Sofía le diga al visitante que está
+   * consultando en vez de confirmar una acción que todavía no ocurrió.
+   */
+  private async escalateForApproval(
+    tool: VigiliaTool<unknown, unknown>,
+    ctx: AuthorizedContext,
+    parsedInput: unknown,
+    startedAt: number,
+  ): Promise<PendingApprovalResult> {
+    const pendingAction = await this.pendingActionsService.create(
+      tool,
+      ctx,
+      parsedInput,
+    );
+
+    const result: PendingApprovalResult = {
+      pendiente: true,
+      pendingActionId: pendingAction.id,
+      mensaje: `Tu solicitud ("${tool.name}") quedó pendiente de aprobación de un residente o conserje.`,
+    };
+
+    await auditToolCall(
+      this.logsService,
+      tool,
+      ctx,
+      parsedInput,
+      result,
+      true,
+      Date.now() - startedAt,
+    );
+
+    return result;
   }
 
   /**
@@ -158,52 +252,5 @@ export class ToolDispatcherService {
       return true;
     }
     return tool.requiredScopes.some((scope) => ctx.scopes.includes(scope));
-  }
-
-  private async audit(
-    tool: VigiliaTool<unknown, unknown>,
-    ctx: AuthorizedContext,
-    input: unknown,
-    output: unknown,
-    success: boolean,
-    durationMs: number,
-    error?: unknown,
-  ): Promise<void> {
-    const isValidationError = error instanceof ZodError;
-
-    await this.logsService.log({
-      level: success ? LogLevel.INFO : LogLevel.WARN,
-      type: LogType.AGENT_TOOL_CALL,
-      service: ServiceName.BACKEND,
-      message: `agent-tool ${tool.name}: ${success ? 'ok' : 'denegado/error'} (${durationMs}ms)`,
-      responseTime: durationMs,
-      correlationId: ctx.requestId,
-      errorMessage: error ? this.describeError(error) : undefined,
-      metadata: {
-        toolName: tool.name,
-        access: tool.access,
-        requiredScopes: tool.requiredScopes,
-        tenantId: ctx.tenantId,
-        userId: ctx.userId ?? null,
-        role: ctx.role,
-        success,
-        validationError: isValidationError,
-        input,
-        output,
-      },
-    });
-
-    if (!success) {
-      this.logger.warn(
-        `Tool "${tool.name}" no se ejecutó (ctx.requestId=${ctx.requestId}): ${this.describeError(error)}`,
-      );
-    }
-  }
-
-  private describeError(error: unknown): string {
-    if (error instanceof Error) {
-      return error.message;
-    }
-    return String(error);
   }
 }

--- a/backend/src/agent/tools/abrir-acceso.tool.spec.ts
+++ b/backend/src/agent/tools/abrir-acceso.tool.spec.ts
@@ -1,0 +1,421 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { AbrirAccesoTool } from './abrir-acceso.tool';
+import {
+  DigitalConciergeService,
+  type TenantScope,
+} from '../../digital-concierge/services/digital-concierge.service';
+import { FamiliesService } from '../../families/families.service';
+import { VisitsService } from '../../visits/visits.service';
+import { VisitStatus, VisitType } from '../../visits/entities/visit.entity';
+import { HubGateway } from '../../hub/hub.gateway';
+import type { ConciergeSession } from '../../digital-concierge/entities/concierge-session.entity';
+import type { Family } from '../../families/entities/family.entity';
+import type { Visit } from '../../visits/entities/visit.entity';
+import type { Vehicle } from '../../vehicles/entities/vehicle.entity';
+import type { AuthorizedContext } from '../types/authorized-context.type';
+
+/**
+ * Fase 2, Bloque F2.2 (docs/modulos/agente-cerebro.md §12) — cobertura de
+ * `AbrirAccesoTool` tras la corrección del hallazgo CRÍTICO de auditoría:
+ * la política de autonomía original autorizaba por CASA (cualquier visita
+ * vigente en la casa de destino, sin comparar identidad), lo que permitía a
+ * un intruso marcar una casa con una visita ajena y pedir la apertura. La
+ * política corregida exige una identidad VERIFICADA (patente LPR o QR
+ * escaneado) que matchee la visita — nunca datos declarados por voz.
+ *
+ * NO llama a la BD ni al hub real: `DigitalConciergeService`/
+ * `FamiliesService`/`VisitsService`/`HubGateway` mockeados.
+ * `resolveVerifiedIdentity` es privado y hoy siempre resuelve `null` (ver su
+ * docstring — no existe todavía un vínculo sesión↔detección/QR); los tests
+ * que necesitan simular una identidad verificada lo espían con
+ * `jest.spyOn(tool as any, 'resolveVerifiedIdentity')`, exactamente el punto
+ * de extensión documentado para cuando ese vínculo se cablee.
+ */
+describe('AbrirAccesoTool', () => {
+  let tool: AbrirAccesoTool;
+  let conciergeService: jest.Mocked<
+    Pick<DigitalConciergeService, 'findSessionForTenant'>
+  >;
+  let familiesService: jest.Mocked<Pick<FamiliesService, 'findByDepartment'>>;
+  let visitsService: jest.Mocked<Pick<VisitsService, 'findAll'>>;
+  let hubGateway: jest.Mocked<
+    Pick<HubGateway, 'isHubConnected' | 'sendToHub' | 'sendToOrganization'>
+  >;
+
+  const NOW = new Date('2026-07-12T12:00:00Z');
+
+  function makeCtx(
+    overrides: Partial<AuthorizedContext> = {},
+  ): AuthorizedContext {
+    return {
+      tenantId: 'condo-A',
+      isSuperAdmin: false,
+      userId: undefined,
+      role: 'hub',
+      scopes: ['digital-concierge.access'],
+      requestId: 'req-1',
+      sessionId: 'session-1',
+      ...overrides,
+    };
+  }
+
+  function makeSession(
+    overrides: Partial<ConciergeSession> = {},
+  ): ConciergeSession {
+    return {
+      id: 'session-row-1',
+      sessionId: 'session-1',
+      organizationId: 'condo-A',
+      hubId: null,
+      destinationHouse: '15',
+      // Datos "declarados" por el visitante durante la llamada — NUNCA deben
+      // por sí solos habilitar autonomía (ese era el bug). Se incluyen acá
+      // para que un test que olvide espiar `resolveVerifiedIdentity` no
+      // pueda, por accidente, hacer pasar un dato declarado como verificado.
+      vehiclePlate: 'DECLARADA-POR-VOZ',
+      visitorName: 'Visitante Anónimo',
+      visitorRut: null,
+      createdVisit: null,
+      ...overrides,
+    } as unknown as ConciergeSession;
+  }
+
+  /** Réplica fiel de la regla real de `findSessionForTenant` (ver otros specs de tools). */
+  function realFindSessionForTenant(session: ConciergeSession) {
+    return jest.fn(
+      (
+        _sessionId: string,
+        tenantScope: TenantScope,
+      ): Promise<ConciergeSession> => {
+        if (
+          !tenantScope.isSuperAdmin &&
+          session.organizationId !== tenantScope.tenantId
+        ) {
+          throw new ForbiddenException(
+            `La sesión "${session.id}" no pertenece al condominio del contexto autorizado`,
+          );
+        }
+        return Promise.resolve(session);
+      },
+    );
+  }
+
+  function makeFamily(organizationId: string | null): Family {
+    return { id: 'family-1', organizationId, name: 'Familia Pérez' } as Family;
+  }
+
+  function makeVisit(overrides: Partial<Visit> = {}): Visit {
+    return {
+      id: 'visit-1',
+      type: VisitType.PEDESTRIAN,
+      status: VisitStatus.PENDING,
+      validFrom: new Date('2026-07-12T10:00:00Z'),
+      validUntil: new Date('2026-07-12T20:00:00Z'),
+      qrCode: null,
+      vehicle: null,
+      ...overrides,
+    } as Visit;
+  }
+
+  /** Espía el punto de extensión documentado en `resolveVerifiedIdentity`. */
+  function mockVerifiedIdentity(
+    identity:
+      | { kind: 'plate'; plate: string }
+      | { kind: 'qr'; qrCode: string }
+      | null,
+  ): jest.SpyInstance {
+    return jest
+      .spyOn(tool as unknown as { resolveVerifiedIdentity: unknown }, 'resolveVerifiedIdentity' as never)
+      .mockResolvedValue(identity as never);
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+
+    conciergeService = { findSessionForTenant: jest.fn() };
+    familiesService = { findByDepartment: jest.fn() };
+    visitsService = { findAll: jest.fn() };
+    hubGateway = {
+      isHubConnected: jest.fn().mockReturnValue(false),
+      sendToHub: jest.fn().mockReturnValue(true),
+      sendToOrganization: jest.fn(),
+    };
+
+    tool = new AbrirAccesoTool(
+      conciergeService as unknown as DigitalConciergeService,
+      familiesService as unknown as FamiliesService,
+      visitsService as unknown as VisitsService,
+      hubGateway as unknown as HubGateway,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe('requiresApproval (política de autonomía, fail-closed por diseño)', () => {
+    it('sin ctx.sessionId escala siempre (true) — no hay hub/casa que validar', async () => {
+      const needsApproval = await tool.requiresApproval(
+        makeCtx({ sessionId: undefined }),
+        { tipo: 'porton' },
+      );
+
+      expect(needsApproval).toBe(true);
+      expect(conciergeService.findSessionForTenant).not.toHaveBeenCalled();
+    });
+
+    it('sin destinationHouse en la sesión, escala (true)', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(
+        makeSession({ destinationHouse: null }),
+      );
+
+      const needsApproval = await tool.requiresApproval(makeCtx(), {
+        tipo: 'porton',
+      });
+
+      expect(needsApproval).toBe(true);
+      expect(familiesService.findByDepartment).not.toHaveBeenCalled();
+    });
+
+    it('ATAQUE DEL AUDITOR (H-CRIT-F2.2): visitante SIN identidad verificada que marca una casa con visita ajena vigente — escala (true), NUNCA abre por la sola existencia de la visita', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+      // La casa de destino SÍ tiene una visita vigente — de otra persona.
+      // `resolveVerifiedIdentity` NO se mockea: se ejerce el comportamiento
+      // real de producción (siempre `null` hoy, ver su docstring).
+      visitsService.findAll.mockResolvedValue([
+        makeVisit({
+          status: VisitStatus.ACTIVE,
+          vehicle: { plate: 'OTRO-VISITANTE' } as Vehicle,
+        }),
+      ]);
+
+      const needsApproval = await tool.requiresApproval(makeCtx(), {
+        tipo: 'porton',
+      });
+
+      expect(needsApproval).toBe(true);
+      // Corta apenas se sabe que no hay identidad — ni siquiera necesita
+      // resolver la familia para descartar la autonomía.
+      expect(familiesService.findByDepartment).not.toHaveBeenCalled();
+      expect(visitsService.findAll).not.toHaveBeenCalled();
+    });
+
+    it('identidad verificada por PATENTE (LPR) que matchea la visita vigente de la casa — NO escala (false), abre autónomo', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      mockVerifiedIdentity({ kind: 'plate', plate: 'abcd12' });
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+      visitsService.findAll.mockResolvedValue([
+        makeVisit({
+          status: VisitStatus.ACTIVE,
+          vehicle: { plate: 'ABCD12' } as Vehicle,
+        }),
+      ]);
+
+      const needsApproval = await tool.requiresApproval(makeCtx(), {
+        tipo: 'porton',
+      });
+
+      expect(needsApproval).toBe(false);
+      expect(visitsService.findAll).toHaveBeenCalledWith({
+        familyId: 'family-1',
+      });
+    });
+
+    it('identidad verificada por QR escaneado que matchea la visita vigente de la casa — NO escala (false)', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      mockVerifiedIdentity({ kind: 'qr', qrCode: 'qr-abc-123' });
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+      visitsService.findAll.mockResolvedValue([
+        makeVisit({ status: VisitStatus.PENDING, qrCode: 'qr-abc-123' }),
+      ]);
+
+      const needsApproval = await tool.requiresApproval(makeCtx(), {
+        tipo: 'porton',
+      });
+
+      expect(needsApproval).toBe(false);
+    });
+
+    it('identidad verificada que NO matchea ninguna visita de la casa (patente distinta) — escala (true)', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      mockVerifiedIdentity({ kind: 'plate', plate: 'ZZZZ99' });
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+      visitsService.findAll.mockResolvedValue([
+        makeVisit({
+          status: VisitStatus.ACTIVE,
+          vehicle: { plate: 'ABCD12' } as Vehicle,
+        }),
+      ]);
+
+      const needsApproval = await tool.requiresApproval(makeCtx(), {
+        tipo: 'porton',
+      });
+
+      expect(needsApproval).toBe(true);
+    });
+
+    it('sin ninguna visita para la casa (aun con identidad verificada), escala (true) — caso "dudoso"', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      mockVerifiedIdentity({ kind: 'plate', plate: 'ABCD12' });
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+      visitsService.findAll.mockResolvedValue([]);
+
+      const needsApproval = await tool.requiresApproval(makeCtx(), {
+        tipo: 'porton',
+      });
+
+      expect(needsApproval).toBe(true);
+    });
+
+    it('con visita que matchea la identidad pero en estado no autorizado (CANCELLED/COMPLETED/DENIED), escala (true)', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      mockVerifiedIdentity({ kind: 'plate', plate: 'ABCD12' });
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+      visitsService.findAll.mockResolvedValue([
+        makeVisit({
+          status: VisitStatus.CANCELLED,
+          vehicle: { plate: 'ABCD12' } as Vehicle,
+        }),
+        makeVisit({
+          id: 'visit-2',
+          status: VisitStatus.COMPLETED,
+          vehicle: { plate: 'ABCD12' } as Vehicle,
+        }),
+      ]);
+
+      const needsApproval = await tool.requiresApproval(makeCtx(), {
+        tipo: 'porton',
+      });
+
+      expect(needsApproval).toBe(true);
+    });
+
+    it('con visita que matchea la identidad pero fuera de la ventana de validez (ya expiró), escala (true)', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      mockVerifiedIdentity({ kind: 'plate', plate: 'ABCD12' });
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+      visitsService.findAll.mockResolvedValue([
+        makeVisit({
+          status: VisitStatus.PENDING,
+          vehicle: { plate: 'ABCD12' } as Vehicle,
+          validFrom: new Date('2026-07-10T00:00:00Z'),
+          validUntil: new Date('2026-07-11T00:00:00Z'), // antes de NOW
+        }),
+      ]);
+
+      const needsApproval = await tool.requiresApproval(makeCtx(), {
+        tipo: 'porton',
+      });
+
+      expect(needsApproval).toBe(true);
+    });
+
+    it('NO alcanza visitas de una familia de otro condominio aun con identidad verificada — escala (true), sin listar sus visitas', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      mockVerifiedIdentity({ kind: 'plate', plate: 'ABCD12' });
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-B'));
+
+      const needsApproval = await tool.requiresApproval(
+        makeCtx({ tenantId: 'condo-A' }),
+        { tipo: 'porton' },
+      );
+
+      expect(needsApproval).toBe(true);
+      expect(visitsService.findAll).not.toHaveBeenCalled();
+    });
+
+    it('un super-admin SÍ puede resolver autonomía sobre la familia de cualquier condominio (bypass intencional), siempre que la identidad matchee', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(makeSession());
+      mockVerifiedIdentity({ kind: 'plate', plate: 'ABCD12' });
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-B'));
+      visitsService.findAll.mockResolvedValue([
+        makeVisit({
+          status: VisitStatus.ACTIVE,
+          vehicle: { plate: 'ABCD12' } as Vehicle,
+        }),
+      ]);
+
+      const needsApproval = await tool.requiresApproval(
+        makeCtx({ tenantId: 'condo-A', isSuperAdmin: true }),
+        { tipo: 'porton' },
+      );
+
+      expect(needsApproval).toBe(false);
+    });
+
+    it('propaga (no traga) el error si la sesión no pertenece al tenant — nunca decide autonomía sobre datos de otro condominio', async () => {
+      conciergeService.findSessionForTenant.mockImplementation(
+        realFindSessionForTenant(makeSession({ organizationId: 'condo-B' })),
+      );
+
+      await expect(
+        tool.requiresApproval(makeCtx({ tenantId: 'condo-A' }), {
+          tipo: 'porton',
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('execute', () => {
+    it('exige ctx.sessionId — lanza BadRequestException sin tocar el hub si falta', async () => {
+      await expect(
+        tool.execute(makeCtx({ sessionId: undefined }), { tipo: 'porton' }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(conciergeService.findSessionForTenant).not.toHaveBeenCalled();
+      expect(hubGateway.sendToHub).not.toHaveBeenCalled();
+      expect(hubGateway.sendToOrganization).not.toHaveBeenCalled();
+    });
+
+    it('dirige la apertura al hub propio de la sesión cuando está conectado (tipo "porton" -> vehicular)', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(
+        makeSession({ hubId: 'hub-001', organizationId: 'condo-A' }),
+      );
+      hubGateway.isHubConnected.mockReturnValue(true);
+
+      const result = await tool.execute(makeCtx(), { tipo: 'porton' });
+
+      expect(hubGateway.sendToHub).toHaveBeenCalledWith(
+        'hub-001',
+        'hub:door_open',
+        expect.objectContaining({ type: 'vehicular' }),
+      );
+      expect(hubGateway.sendToOrganization).not.toHaveBeenCalled();
+      expect(result.abierto).toBe(true);
+      expect(result.mensaje).toContain('portón');
+    });
+
+    it('(a) dirige por condominio (sendToOrganization) cuando el hub propio no está conectado (tipo "puerta" -> pedestrian)', async () => {
+      conciergeService.findSessionForTenant.mockResolvedValue(
+        makeSession({ hubId: 'hub-001', organizationId: 'condo-A' }),
+      );
+      hubGateway.isHubConnected.mockReturnValue(false);
+
+      const result = await tool.execute(makeCtx(), { tipo: 'puerta' });
+
+      expect(hubGateway.sendToHub).not.toHaveBeenCalled();
+      expect(hubGateway.sendToOrganization).toHaveBeenCalledWith(
+        'condo-A',
+        'hub:door_open',
+        expect.objectContaining({ type: 'pedestrian' }),
+      );
+      expect(result.abierto).toBe(true);
+      expect(result.mensaje).toContain('puerta');
+    });
+
+    it('(d) nunca dirige la apertura a la organización de OTRO condominio — la sesión ya viene tenant-scoped', async () => {
+      conciergeService.findSessionForTenant.mockImplementation(
+        realFindSessionForTenant(makeSession({ organizationId: 'condo-B' })),
+      );
+
+      await expect(
+        tool.execute(makeCtx({ tenantId: 'condo-A' }), { tipo: 'porton' }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(hubGateway.sendToHub).not.toHaveBeenCalled();
+      expect(hubGateway.sendToOrganization).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/agent/tools/abrir-acceso.tool.ts
+++ b/backend/src/agent/tools/abrir-acceso.tool.ts
@@ -1,0 +1,324 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { FamiliesService } from '../../families/families.service';
+import { DigitalConciergeService } from '../../digital-concierge/services/digital-concierge.service';
+import type { ConciergeSession } from '../../digital-concierge/entities/concierge-session.entity';
+import { HubGateway } from '../../hub/hub.gateway';
+import { VisitStatus } from '../../visits/entities/visit.entity';
+import { VisitsService } from '../../visits/visits.service';
+import type { AuthorizedContext } from '../types/authorized-context.type';
+import type { VigiliaTool } from '../types/vigilia-tool.type';
+
+const inputSchema = z.object({
+  tipo: z
+    .enum(['porton', 'puerta'])
+    .describe(
+      'Qué acceso físico abrir: "porton" para el acceso vehicular, "puerta" para el acceso peatonal.',
+    ),
+});
+type AbrirAccesoInput = z.infer<typeof inputSchema>;
+
+const outputSchema = z.object({
+  abierto: z.boolean(),
+  mensaje: z.string(),
+});
+type AbrirAccesoOutput = z.infer<typeof outputSchema>;
+
+/**
+ * Estados de `Visit` que cuentan como "acceso autorizado" para la política de
+ * autonomía de abajo — MISMO set que `ACTIVE_STATUSES` de
+ * `ConsultarVisitasTool` (docs/modulos/agente-cerebro.md §12): una visita
+ * `PENDING` (el residente ya la pre-registró, el visitante aún no marca
+ * entrada), `ACTIVE` (ya en curso) o `READY_FOR_REENTRY` (puede reingresar) es
+ * "visita pre-aprobada" a efectos de abrir el acceso sin escalar. No se
+ * extrae a un util compartido para no acoplar dos tools que hoy evolucionan
+ * independiente — si un tercer consumidor necesita el mismo criterio, vale la
+ * pena centralizarlo entonces (ver "deuda" en el reporte de la tarea).
+ */
+const PRE_APPROVED_VISIT_STATUSES = new Set<VisitStatus>([
+  VisitStatus.PENDING,
+  VisitStatus.ACTIVE,
+  VisitStatus.READY_FOR_REENTRY,
+]);
+
+/**
+ * CORRECCIÓN CRÍTICA (auditoría de seguridad, hallazgo F2.2 — "autoriza por
+ * casa, no por persona"): identidad del visitante VERIFICADA por un canal que
+ * un atacante no controla — la única evidencia que habilita la apertura
+ * autónoma (ver `requiresApproval` y `hasVerifiedPreApprovedVisit` abajo).
+ *
+ * NUNCA se construye a partir de lo que el visitante DECLARA por voz
+ * (`ConciergeSession.vehiclePlate`/`visitorName`/`visitorRut`, capturados por
+ * `guardar_datos_visitante.tool.ts`) — esos campos son atacante-controlados
+ * (el visitante los dicta, y puede reescribirlos vía esa misma tool), que es
+ * exactamente el vector que explotó el auditor: marcar una casa con una
+ * visita ajena y pedir la apertura. Solo cuentan:
+ *  - `plate`: patente LEÍDA por la cámara del portón (LPR/`PlateDetection`),
+ *    nunca tecleada o dicha por el visitante.
+ *  - `qr`: código de un QR ESCANEADO por un lector físico (`Visit.qrCode`).
+ */
+type VerifiedVisitorIdentity =
+  | { readonly kind: 'plate'; readonly plate: string }
+  | { readonly kind: 'qr'; readonly qrCode: string };
+
+/**
+ * Bloque F2.2 (docs/modulos/agente-cerebro.md §12) — política de autonomía
+ * condicional para la apertura física de accesos. `access: 'write'`: es la
+ * tool más sensible del catálogo (efecto físico real, no reversible una vez
+ * emitido el pulso del relé).
+ *
+ * DECISIÓN DE DISEÑO — una sola tool con `tipo`, no dos (`abrir_porton` /
+ * `abrir_puerta`): el hardware YA distingue el acceso por un campo
+ * (`hub:door_open` → `{ type: 'vehicular' | 'pedestrian' }`, ver
+ * `DigitalConciergeService.respondToVisitor` y
+ * `vigilia-hub/src/services/websocket-client.service.ts::onDoorOpenCommand`),
+ * y la política de autonomía (¿hay visita pre-aprobada?) es IDÉNTICA para
+ * ambos casos — depende de la casa/visita, no del tipo de acceso. Dos tools
+ * duplicarían textualmente `requiresApproval`/`execute` sin ganar nada; un
+ * parámetro sigue el mismo patrón que `ConsultarVisitasTool.soloActivas` o
+ * `ConsultarVehiculoTool.patente` (un solo concepto, una tool).
+ *
+ * POLÍTICA DE AUTONOMÍA (corregida tras hallazgo CRÍTICO de auditoría —
+ * F2.2 original autorizaba por CASA, sin comparar identidad: cualquier
+ * visitante que marcara una casa con una visita ajena vigente abría el
+ * acceso. Decisión de producto de Benjamin: la apertura autónoma exige
+ * identidad VERIFICADA, nunca declarada): el agente abre SOLO
+ * (`requiresApproval` resuelve `false`) si, y solo si, existe una
+ * `VerifiedVisitorIdentity` (patente LEÍDA por LPR o QR ESCANEADO — ver tipo
+ * arriba) asociada a ESTA sesión que matchea una visita pre-aprobada vigente
+ * (mismo set de estados que `ConsultarVisitasTool`/el flujo determinista de
+ * LPR — ver `PRE_APPROVED_VISIT_STATUSES` arriba y
+ * `VisitsService.validateAccess`, que también exige la ventana
+ * `validFrom`/`validUntil`) para la casa de destino.
+ *
+ * En CUALQUIER otro caso — sin casa resuelta, sin sesión de conserjería, sin
+ * identidad verificada, o identidad verificada que NO matchea ninguna visita
+ * vigente de esa casa — escala al residente/conserje (F2.1). Fail-closed por
+ * diseño: toda rama ambigua o no cubierta explícitamente escala, nunca abre.
+ * Ver `resolveVerifiedIdentity` para el estado actual (y la deuda) de cómo se
+ * obtiene la identidad verificada de una sesión de citófono.
+ *
+ * `casa` de destino: se deriva de `ConciergeSession.destinationHouse` (NUNCA
+ * de un input del modelo) — misma razón que `tenantId`/`sessionId` en
+ * `AuthorizedContext` (regla dura #1 del §5): un modelo comprometido no debe
+ * poder decidir SOBRE QUÉ CASA se evalúa la autonomía pasándola como
+ * parámetro. Por eso esta tool, a diferencia de `buscar_residente`/
+ * `consultar_visitas`, exige `ctx.sessionId` (igual que `finalizar_llamada`/
+ * `notificar_residente`) — no tiene sentido fuera de una sesión física real.
+ *
+ * EMISIÓN AL HUB: reusa `HubGateway.sendToHub`/`sendToOrganization` +
+ * `DigitalConciergeService.findSessionForTenant` (misma dupla que ya usan
+ * `finalizar_llamada`/`notificar_residente` para resolver+validar tenant de
+ * la sesión) — dirigido por `session.hubId` (o, si no está conectado, por
+ * `session.organizationId`), NUNCA un broadcast global (hallazgo H2, ya
+ * corregido en A1.1). La lógica de "hub propio vs. broadcast al condominio"
+ * duplica ~4 líneas de `DigitalConciergeService.notifyHub` (privado, no
+ * exportado) en vez de tocar ese archivo — fuera del alcance de coordinación
+ * de esta tarea (solo módulo `agent` + `hub.gateway`); ver "deuda" en el
+ * reporte.
+ *
+ * IDEMPOTENCIA: reabrir por un retry (o por `PendingActionsService.approve`
+ * reintentando tras un `failed`, ver su FIX 2) solo reactiva el relé del hub
+ * — sin efecto acumulativo dañino (mismo pulso, mismo resultado).
+ *
+ * `requiredScopes`: se mantiene `digital-concierge.access` (el baseline fijo
+ * que trae toda sesión de hub físico, ver `authorized-context.factory.ts`) en
+ * vez de exigir un scope más fuerte — un hub NO tiene RBAC granular (es una
+ * credencial de máquina, no un `User` con roles), así que cualquier scope
+ * adicional dejaría a la tool inalcanzable desde el citófono, que es
+ * justamente donde se necesita. Si en el futuro un canal humano (conserje
+ * operando el agente por texto) debiera requerir un permiso más fuerte para
+ * esta tool específica, hace falta agregar ese scope al baseline/RBAC
+ * primero — fuera de alcance acá (ver "deuda").
+ */
+@Injectable()
+export class AbrirAccesoTool
+  implements VigiliaTool<AbrirAccesoInput, AbrirAccesoOutput>
+{
+  readonly name = 'abrir_acceso';
+  readonly description =
+    'Abre el portón vehicular o la puerta peatonal del condominio para el visitante de esta llamada. Si el visitante no tiene una visita pre-aprobada vigente, la solicitud queda pendiente de aprobación de un residente o conserje — nunca prometas la apertura antes de que la herramienta confirme que se abrió.';
+  readonly inputSchema = inputSchema;
+  readonly outputSchema = outputSchema;
+  readonly access = 'write' as const;
+  readonly requiredScopes = ['digital-concierge.access'];
+
+  constructor(
+    private readonly conciergeService: DigitalConciergeService,
+    private readonly familiesService: FamiliesService,
+    private readonly visitsService: VisitsService,
+    private readonly hubGateway: HubGateway,
+  ) {}
+
+  /**
+   * Política de autonomía condicional (ver docstring de la clase). Fail-safe
+   * por diseño: cualquier rama sin evidencia explícita de "visita
+   * pre-aprobada vigente" devuelve `true` (escala) — nunca `false` por
+   * default.
+   */
+  readonly requiresApproval = async (
+    ctx: AuthorizedContext,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- firma exigida por VigiliaTool.requiresApproval (mismo patrón que `_input` en finalizar-llamada.tool.ts): el criterio de autonomía no depende de `tipo`, solo de la casa/visita.
+    _input: AbrirAccesoInput,
+  ): Promise<boolean> => {
+    if (!ctx.sessionId) {
+      return true;
+    }
+
+    const session = await this.conciergeService.findSessionForTenant(
+      ctx.sessionId,
+      ctx,
+    );
+
+    if (!session.destinationHouse) {
+      return true;
+    }
+
+    const verifiedIdentity = await this.resolveVerifiedIdentity(session);
+
+    const hasVerifiedPreApprovedVisit =
+      await this.hasVerifiedPreApprovedVisit(
+        ctx,
+        session.destinationHouse,
+        verifiedIdentity,
+      );
+
+    return !hasVerifiedPreApprovedVisit;
+  };
+
+  async execute(
+    ctx: AuthorizedContext,
+    input: AbrirAccesoInput,
+  ): Promise<AbrirAccesoOutput> {
+    if (!ctx.sessionId) {
+      throw new BadRequestException(
+        `La tool "${this.name}" requiere una sesión de conserjería activa (ctx.sessionId)`,
+      );
+    }
+
+    // Re-resuelve la sesión (tenant-scoped) en vez de confiar en lo que haya
+    // evaluado `requiresApproval` — mismo criterio defensivo que
+    // `finalizar_llamada`/`notificar_residente`: `execute()` nunca asume que
+    // ya se validó nada, se valida de nuevo acá.
+    const session = await this.conciergeService.findSessionForTenant(
+      ctx.sessionId,
+      ctx,
+    );
+
+    const hubEvent = 'hub:door_open';
+    const payload = {
+      type: input.tipo === 'porton' ? 'vehicular' : 'pedestrian',
+      // `visitId` es informativo para el hub (ver
+      // websocket-client.service.ts::onDoorOpenCommand, que solo lee
+      // `data.type`) — no siempre hay una `Visit` asociada (p.ej. autonomía
+      // por visita pre-aprobada que aún no hizo check-in).
+      visitId: session.createdVisit?.id ?? null,
+    };
+
+    if (session.hubId && this.hubGateway.isHubConnected(session.hubId)) {
+      this.hubGateway.sendToHub(session.hubId, hubEvent, payload);
+    } else {
+      this.hubGateway.sendToOrganization(
+        session.organizationId,
+        hubEvent,
+        payload,
+      );
+    }
+
+    return {
+      abierto: true,
+      mensaje:
+        input.tipo === 'porton'
+          ? 'Listo, el portón se está abriendo.'
+          : 'Listo, la puerta se está abriendo.',
+    };
+  }
+
+  /**
+   * Resuelve la identidad VERIFICADA (si la hay) asociada a esta
+   * `ConciergeSession` — patente leída por LPR o QR escaneado (ver
+   * `VerifiedVisitorIdentity` arriba). NUNCA construye la identidad a partir
+   * de `session.vehiclePlate`/`visitorName`/`visitorRut` (voz, sin verificar).
+   *
+   * DEUDA (hallazgo de esta corrección — ver reporte de la tarea):
+   * `ConciergeSession` (concierge-session.entity.ts) hoy NO tiene ningún
+   * campo que la vincule con una `PlateDetection`/`AccessAttempt` (patente
+   * leída por la cámara del portón — ver `DetectionsService.createDetection`,
+   * un flujo 100% separado que abre el acceso directo sin pasar nunca por una
+   * `ConciergeSession`) ni con un `Visit.qrCode` escaneado. No existe hoy
+   * ningún punto del sistema que asocie una detección LPR o un escaneo de QR
+   * a la sesión de citófono en curso.
+   *
+   * Mientras ese vínculo no se cablee, esta función devuelve SIEMPRE `null`
+   * — fail-closed: TODA apertura solicitada desde el citófono escala al
+   * residente/conserje, que es el comportamiento seguro. Cuando se implemente
+   * la asociación real (p.ej. agregar `session.verifiedPlateDetectionId` /
+   * `session.verifiedQrCode`, poblados por el flujo que hoy conecta LPR/QR
+   * con el hub), esta es la ÚNICA función que debe cambiar.
+   */
+  private async resolveVerifiedIdentity(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- la sesión es el punto de extensión: cuando exista el vínculo real, se lee desde acá (ver DEUDA arriba).
+    _session: ConciergeSession,
+  ): Promise<VerifiedVisitorIdentity | null> {
+    return null;
+  }
+
+  /**
+   * ¿La identidad VERIFICADA del visitante matchea, para la casa de destino,
+   * una `Visit` cuyo estado y ventana de validez la hacen "pre-aprobada"
+   * AHORA? Mismo criterio de estados que `ConsultarVisitasTool` +
+   * `VisitsService.validateAccess` (ventana `validFrom`/`validUntil`) — no se
+   * reusa `validateAccess` directamente porque también acepta un identificador
+   * suelto sin exigir que venga de una sesión verificada.
+   *
+   * Sin identidad verificada (`identity === null`) devuelve `false` de
+   * inmediato — NUNCA autoriza por la sola existencia de una visita para la
+   * casa (ese era exactamente el bug que reportó el auditor: autorizaba por
+   * casa, no por persona).
+   *
+   * SEGURIDAD: `VisitsService.findAll` NO es tenant-aware (mismo hallazgo que
+   * documenta `ConsultarVisitasTool`) — por eso el `familyId` nunca sale del
+   * input del modelo, se deriva de `FamiliesService.findByDepartment`
+   * (tenant-scoped) y se re-valida `family.organizationId` contra
+   * `ctx.tenantId` ANTES de listar sus visitas.
+   */
+  private async hasVerifiedPreApprovedVisit(
+    ctx: AuthorizedContext,
+    casa: string,
+    identity: VerifiedVisitorIdentity | null,
+  ): Promise<boolean> {
+    if (!identity) {
+      return false;
+    }
+
+    const family = await this.familiesService.findByDepartment(casa);
+
+    if (
+      !family ||
+      (!ctx.isSuperAdmin && family.organizationId !== ctx.tenantId)
+    ) {
+      return false;
+    }
+
+    const visits = await this.visitsService.findAll({ familyId: family.id });
+    const now = new Date();
+
+    return visits.some((visit) => {
+      if (!PRE_APPROVED_VISIT_STATUSES.has(visit.status)) {
+        return false;
+      }
+      if (!(visit.validFrom <= now && visit.validUntil >= now)) {
+        return false;
+      }
+
+      if (identity.kind === 'plate') {
+        return (
+          !!visit.vehicle?.plate &&
+          visit.vehicle.plate.toUpperCase() === identity.plate.toUpperCase()
+        );
+      }
+
+      return !!visit.qrCode && visit.qrCode === identity.qrCode;
+    });
+  }
+}

--- a/backend/src/agent/tools/consultar-accesos-recientes.tool.spec.ts
+++ b/backend/src/agent/tools/consultar-accesos-recientes.tool.spec.ts
@@ -1,0 +1,116 @@
+import { ConsultarAccesosRecientesTool } from './consultar-accesos-recientes.tool';
+import { DetectionsService } from '../../detections/detections.service';
+import type { AccessAttempt } from '../../detections/entities/access-attempt.entity';
+import type { PlateDetection } from '../../detections/entities/plate-detection.entity';
+import type { User } from '../../users/entities/user.entity';
+import type { AuthorizedContext } from '../types/authorized-context.type';
+
+/**
+ * Fase 2, Bloque F2.1 — cobertura de `ConsultarAccesosRecientesTool`
+ * (docs/modulos/agente-cerebro.md §12). NO llama a la BD: `DetectionsService`
+ * mockeado.
+ *
+ * A diferencia de `consultar_vehiculo`/`consultar_visitas`, acá el
+ * aislamiento por tenant se delega en `DetectionsService.listAttempts`
+ * (parámetro `tenantScope` agregado en este bloque) — el test verifica que
+ * la tool SIEMPRE pasa `{ organizationId: ctx.tenantId, isSuperAdmin }`, no
+ * que confía en el default sin filtro.
+ */
+describe('ConsultarAccesosRecientesTool', () => {
+  let tool: ConsultarAccesosRecientesTool;
+  let detectionsService: jest.Mocked<Pick<DetectionsService, 'listAttempts'>>;
+
+  function makeCtx(
+    overrides: Partial<AuthorizedContext> = {},
+  ): AuthorizedContext {
+    return {
+      tenantId: 'condo-A',
+      isSuperAdmin: false,
+      userId: undefined,
+      role: 'hub',
+      scopes: ['digital-concierge.access'],
+      requestId: 'req-1',
+      ...overrides,
+    };
+  }
+
+  function makeAttempt(overrides: Partial<AccessAttempt> = {}): AccessAttempt {
+    return {
+      id: 'attempt-1',
+      decision: 'Permitido',
+      reason: 'Vehículo residente registrado y activo',
+      createdAt: new Date('2026-07-12T10:00:00Z'),
+      detection: { plate: 'ABCD12' } as unknown as PlateDetection,
+      residente: { name: 'Juan Pérez' } as unknown as User,
+      ...overrides,
+    } as AccessAttempt;
+  }
+
+  beforeEach(() => {
+    detectionsService = { listAttempts: jest.fn().mockResolvedValue([]) };
+    tool = new ConsultarAccesosRecientesTool(
+      detectionsService as unknown as DetectionsService,
+    );
+  });
+
+  it('pasa el tenant del ctx (organizationId/isSuperAdmin) a listAttempts, con el límite por defecto', async () => {
+    await tool.execute(
+      makeCtx({ tenantId: 'condo-A', isSuperAdmin: false }),
+      {},
+    );
+
+    expect(detectionsService.listAttempts).toHaveBeenCalledWith(10, {
+      organizationId: 'condo-A',
+      isSuperAdmin: false,
+    });
+  });
+
+  it('respeta el límite explícito del input', async () => {
+    await tool.execute(makeCtx(), { limite: 5 });
+
+    expect(detectionsService.listAttempts).toHaveBeenCalledWith(5, {
+      organizationId: 'condo-A',
+      isSuperAdmin: false,
+    });
+  });
+
+  it('mapea los AccessAttempt a la forma de salida esperada', async () => {
+    detectionsService.listAttempts.mockResolvedValue([
+      makeAttempt(),
+      makeAttempt({
+        id: 'attempt-2',
+        decision: 'Denegado',
+        residente: null,
+        detection: null as unknown as PlateDetection,
+      }),
+    ]);
+
+    const result = await tool.execute(makeCtx(), {});
+
+    expect(result.cantidad).toBe(2);
+    expect(result.accesos[0]).toEqual({
+      patente: 'ABCD12',
+      decision: 'Permitido',
+      motivo: 'Vehículo residente registrado y activo',
+      fecha: '2026-07-12T10:00:00.000Z',
+      residente: 'Juan Pérez',
+    });
+    expect(result.accesos[1]).toMatchObject({
+      patente: null,
+      residente: null,
+      decision: 'Denegado',
+    });
+  });
+
+  it('un super-admin propaga isSuperAdmin:true — sin filtro de tenant en listAttempts', async () => {
+    await tool.execute(
+      makeCtx({ tenantId: 'condo-A', isSuperAdmin: true }),
+      {},
+    );
+
+    expect(detectionsService.listAttempts).toHaveBeenCalledWith(10, {
+      organizationId: 'condo-A',
+      isSuperAdmin: true,
+    });
+  });
+});

--- a/backend/src/agent/tools/consultar-accesos-recientes.tool.ts
+++ b/backend/src/agent/tools/consultar-accesos-recientes.tool.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { DetectionsService } from '../../detections/detections.service';
+import type { AuthorizedContext } from '../types/authorized-context.type';
+import type { VigiliaTool } from '../types/vigilia-tool.type';
+
+const inputSchema = z.object({
+  limite: z
+    .number()
+    .int()
+    .positive()
+    .max(50)
+    .optional()
+    .describe(
+      'Cantidad máxima de accesos recientes a devolver (por defecto 10, máximo 50).',
+    ),
+});
+type ConsultarAccesosRecientesInput = z.infer<typeof inputSchema>;
+
+const accesoSchema = z.object({
+  patente: z.string().nullable(),
+  decision: z.string(),
+  motivo: z.string().nullable(),
+  fecha: z.string(),
+  residente: z.string().nullable(),
+});
+
+const outputSchema = z.object({
+  cantidad: z.number().int().nonnegative(),
+  accesos: z.array(accesoSchema),
+});
+type ConsultarAccesosRecientesOutput = z.infer<typeof outputSchema>;
+
+const DEFAULT_LIMIT = 10;
+
+/**
+ * Tercera `VigiliaTool` de consulta de Fase 2 (Bloque F2.1 —
+ * docs/modulos/agente-cerebro.md §12). `access: 'read'`. Fuente: `AccessAttempt`
+ * (decisión de acceso ya tomada — Permitido/Denegado/Pendiente), no
+ * `PlateDetection` cruda: es la entidad que responde "qué pasó en el acceso",
+ * que es lo que un residente/conserje pregunta por el citófono/chat.
+ *
+ * SEGURIDAD: a diferencia de `Visit`, `AccessAttempt.organizationId` (y el de
+ * `PlateDetection` del que hereda) SÍ se estampa de forma confiable en cada
+ * creación — resource-derived desde la cámara asociada
+ * (`DetectionsService.resolveCameraOrganizationId`), no desde
+ * `TenantContext`. Por eso `DetectionsService.listAttempts` puede filtrar
+ * directo por `organizationId` (parámetro `tenantScope`, agregado en este
+ * bloque — ver su docstring) en vez de necesitar el rodeo de
+ * "derivar-y-comparar" que usan `consultar_vehiculo`/`consultar_visitas`.
+ */
+@Injectable()
+export class ConsultarAccesosRecientesTool
+  implements
+    VigiliaTool<ConsultarAccesosRecientesInput, ConsultarAccesosRecientesOutput>
+{
+  readonly name = 'consultar_accesos_recientes';
+  readonly description =
+    'Lista los accesos (entradas/salidas de vehículos) más recientes del condominio, con su decisión (Permitido/Denegado/Pendiente) y el residente asociado si aplica.';
+  readonly inputSchema = inputSchema;
+  readonly outputSchema = outputSchema;
+  readonly access = 'read' as const;
+  readonly requiresApproval = false;
+  readonly requiredScopes = ['digital-concierge.access'];
+
+  constructor(private readonly detectionsService: DetectionsService) {}
+
+  async execute(
+    ctx: AuthorizedContext,
+    input: ConsultarAccesosRecientesInput,
+  ): Promise<ConsultarAccesosRecientesOutput> {
+    const limite = input.limite ?? DEFAULT_LIMIT;
+
+    const attempts = await this.detectionsService.listAttempts(limite, {
+      organizationId: ctx.tenantId,
+      isSuperAdmin: ctx.isSuperAdmin,
+    });
+
+    return {
+      cantidad: attempts.length,
+      accesos: attempts.map((attempt) => ({
+        patente: attempt.detection?.plate ?? null,
+        decision: attempt.decision,
+        motivo: attempt.reason,
+        fecha: attempt.createdAt.toISOString(),
+        residente: attempt.residente?.name ?? null,
+      })),
+    };
+  }
+}

--- a/backend/src/agent/tools/consultar-vehiculo.tool.spec.ts
+++ b/backend/src/agent/tools/consultar-vehiculo.tool.spec.ts
@@ -1,0 +1,116 @@
+import { ConsultarVehiculoTool } from './consultar-vehiculo.tool';
+import { VehiclesService } from '../../vehicles/vehicles.service';
+import type { Vehicle } from '../../vehicles/entities/vehicle.entity';
+import type { User } from '../../users/entities/user.entity';
+import type { AuthorizedContext } from '../types/authorized-context.type';
+
+/**
+ * Fase 2, Bloque F2.1 — cobertura de `ConsultarVehiculoTool`
+ * (docs/modulos/agente-cerebro.md §12). NO llama a la BD: `VehiclesService`
+ * mockeado.
+ *
+ * Incluye la regresión cross-tenant que exige §6 del diseño: `findByPlate`
+ * de `VehiclesService` es DELIBERADAMENTE no tenant-aware (lo usa el worker
+ * LPR sin sesión de usuario), así que la tool debe re-validar
+ * `vehicle.organizationId` contra `ctx.tenantId` ANTES de devolver
+ * cualquier dato del vehículo encontrado.
+ */
+describe('ConsultarVehiculoTool', () => {
+  let tool: ConsultarVehiculoTool;
+  let vehiclesService: jest.Mocked<Pick<VehiclesService, 'findByPlate'>>;
+
+  function makeCtx(
+    overrides: Partial<AuthorizedContext> = {},
+  ): AuthorizedContext {
+    return {
+      tenantId: 'condo-A',
+      isSuperAdmin: false,
+      userId: undefined,
+      role: 'hub',
+      scopes: ['digital-concierge.access'],
+      requestId: 'req-1',
+      ...overrides,
+    };
+  }
+
+  function makeVehicle(
+    organizationId: string | null,
+    overrides: Partial<Vehicle> = {},
+  ): Vehicle {
+    return {
+      id: 'vehicle-1',
+      organizationId,
+      plate: 'ABCD12',
+      brand: 'Toyota',
+      model: 'Yaris',
+      color: 'Rojo',
+      year: 2020,
+      vehicleType: 'residente',
+      accessLevel: 'permanente',
+      active: true,
+      owner: { id: 'user-1', name: 'Juan Pérez' } as unknown as User,
+      ownerId: 'user-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    } as Vehicle;
+  }
+
+  beforeEach(() => {
+    vehiclesService = { findByPlate: jest.fn() };
+    tool = new ConsultarVehiculoTool(
+      vehiclesService as unknown as VehiclesService,
+    );
+  });
+
+  it('devuelve encontrado:false cuando no existe ningún vehículo con esa patente', async () => {
+    vehiclesService.findByPlate.mockResolvedValue(null);
+
+    const result = await tool.execute(makeCtx(), { patente: 'ZZZZ99' });
+
+    expect(result.encontrado).toBe(false);
+    expect(vehiclesService.findByPlate).toHaveBeenCalledWith('ZZZZ99');
+  });
+
+  it('devuelve los datos del vehículo cuando pertenece al condominio del ctx', async () => {
+    vehiclesService.findByPlate.mockResolvedValue(makeVehicle('condo-A'));
+
+    const result = await tool.execute(makeCtx(), { patente: 'ABCD12' });
+
+    expect(result).toEqual({
+      encontrado: true,
+      patente: 'ABCD12',
+      marca: 'Toyota',
+      modelo: 'Yaris',
+      color: 'Rojo',
+      tipo: 'residente',
+      nivelAcceso: 'permanente',
+      activo: true,
+      propietario: 'Juan Pérez',
+    });
+  });
+
+  describe('regresión cross-tenant (§6 del diseño)', () => {
+    it('NO revela un vehículo de otro condominio — responde "no encontrado", no "prohibido"', async () => {
+      vehiclesService.findByPlate.mockResolvedValue(makeVehicle('condo-B'));
+
+      const result = await tool.execute(makeCtx({ tenantId: 'condo-A' }), {
+        patente: 'ABCD12',
+      });
+
+      expect(result.encontrado).toBe(false);
+      expect(result).not.toHaveProperty('marca');
+    });
+
+    it('un super-admin SÍ puede consultar un vehículo de cualquier condominio (bypass intencional)', async () => {
+      vehiclesService.findByPlate.mockResolvedValue(makeVehicle('condo-B'));
+
+      const result = await tool.execute(
+        makeCtx({ tenantId: 'condo-A', isSuperAdmin: true }),
+        { patente: 'ABCD12' },
+      );
+
+      expect(result.encontrado).toBe(true);
+    });
+  });
+});

--- a/backend/src/agent/tools/consultar-vehiculo.tool.ts
+++ b/backend/src/agent/tools/consultar-vehiculo.tool.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { VehiclesService } from '../../vehicles/vehicles.service';
+import type { AuthorizedContext } from '../types/authorized-context.type';
+import type { VigiliaTool } from '../types/vigilia-tool.type';
+
+const inputSchema = z.object({
+  patente: z
+    .string()
+    .min(1)
+    .describe(
+      'Patente del vehículo tal como la dijo o leyó el visitante/cámara (ej: "ABCD12", "AB1234").',
+    ),
+});
+type ConsultarVehiculoInput = z.infer<typeof inputSchema>;
+
+const outputSchema = z.object({
+  encontrado: z.boolean(),
+  mensaje: z.string().optional(),
+  patente: z.string().optional(),
+  marca: z.string().nullable().optional(),
+  modelo: z.string().nullable().optional(),
+  color: z.string().nullable().optional(),
+  tipo: z.string().nullable().optional(),
+  nivelAcceso: z.string().nullable().optional(),
+  activo: z.boolean().nullable().optional(),
+  propietario: z.string().nullable().optional(),
+});
+type ConsultarVehiculoOutput = z.infer<typeof outputSchema>;
+
+/**
+ * Primera `VigiliaTool` de consulta de Fase 2 (Bloque F2.1 —
+ * docs/modulos/agente-cerebro.md §12). `access: 'read'` — no muta estado.
+ *
+ * SEGURIDAD: `VehiclesService.findByPlate` es DELIBERADAMENTE no
+ * tenant-aware (lo usa `DetectionsService` en el flujo del worker LPR, sin
+ * sesión de usuario — ver el comentario del propio constructor de
+ * `VehiclesService`). Esta tool NO puede confiar en el servicio para el
+ * aislamiento: re-valida acá que `vehicle.organizationId` coincida con
+ * `ctx.tenantId` (mismo patrón de `NotificarResidenteTool`/fix M1, §6 del
+ * diseño) ANTES de devolver cualquier dato — si no coincide, responde
+ * "no encontrado" en vez de "prohibido", para no confirmarle a un modelo
+ * comprometido que la patente SÍ existe en otro condominio.
+ */
+@Injectable()
+export class ConsultarVehiculoTool
+  implements VigiliaTool<ConsultarVehiculoInput, ConsultarVehiculoOutput>
+{
+  readonly name = 'consultar_vehiculo';
+  readonly description =
+    'Busca un vehículo registrado por su patente. Devuelve marca, modelo, color, tipo de acceso y propietario si existe y pertenece a este condominio.';
+  readonly inputSchema = inputSchema;
+  readonly outputSchema = outputSchema;
+  readonly access = 'read' as const;
+  readonly requiresApproval = false;
+  readonly requiredScopes = ['digital-concierge.access'];
+
+  constructor(private readonly vehiclesService: VehiclesService) {}
+
+  async execute(
+    ctx: AuthorizedContext,
+    input: ConsultarVehiculoInput,
+  ): Promise<ConsultarVehiculoOutput> {
+    const vehicle = await this.vehiclesService.findByPlate(input.patente);
+
+    if (
+      !vehicle ||
+      (!ctx.isSuperAdmin && vehicle.organizationId !== ctx.tenantId)
+    ) {
+      return {
+        encontrado: false,
+        mensaje: `No se encontró ningún vehículo registrado con patente ${input.patente}.`,
+      };
+    }
+
+    return {
+      encontrado: true,
+      patente: vehicle.plate,
+      marca: vehicle.brand,
+      modelo: vehicle.model,
+      color: vehicle.color,
+      tipo: vehicle.vehicleType,
+      nivelAcceso: vehicle.accessLevel,
+      activo: vehicle.active,
+      propietario: vehicle.owner?.name ?? null,
+    };
+  }
+}

--- a/backend/src/agent/tools/consultar-visitas.tool.spec.ts
+++ b/backend/src/agent/tools/consultar-visitas.tool.spec.ts
@@ -1,0 +1,134 @@
+import { ConsultarVisitasTool } from './consultar-visitas.tool';
+import { FamiliesService } from '../../families/families.service';
+import { VisitsService } from '../../visits/visits.service';
+import { VisitStatus, VisitType } from '../../visits/entities/visit.entity';
+import type { Family } from '../../families/entities/family.entity';
+import type { Visit } from '../../visits/entities/visit.entity';
+import type { AuthorizedContext } from '../types/authorized-context.type';
+
+/**
+ * Fase 2, Bloque F2.1 — cobertura de `ConsultarVisitasTool`
+ * (docs/modulos/agente-cerebro.md §12). NO llama a la BD:
+ * `FamiliesService`/`VisitsService` mockeados.
+ *
+ * Incluye la regresión cross-tenant que exige §6 del diseño: en esta rama
+ * `VisitsService.findAll` NO es tenant-aware, así que la tool debe re-validar
+ * `family.organizationId` contra `ctx.tenantId` ANTES de listar sus visitas
+ * — el `familyId` nunca sale del input del modelo (siempre se deriva de
+ * `FamiliesService.findByDepartment`, ya tenant-scoped).
+ */
+describe('ConsultarVisitasTool', () => {
+  let tool: ConsultarVisitasTool;
+  let familiesService: jest.Mocked<Pick<FamiliesService, 'findByDepartment'>>;
+  let visitsService: jest.Mocked<Pick<VisitsService, 'findAll'>>;
+
+  function makeCtx(
+    overrides: Partial<AuthorizedContext> = {},
+  ): AuthorizedContext {
+    return {
+      tenantId: 'condo-A',
+      isSuperAdmin: false,
+      userId: undefined,
+      role: 'hub',
+      scopes: ['digital-concierge.access'],
+      requestId: 'req-1',
+      ...overrides,
+    };
+  }
+
+  function makeFamily(organizationId: string | null): Family {
+    return { id: 'family-1', organizationId, name: 'Familia Pérez' } as Family;
+  }
+
+  function makeVisit(overrides: Partial<Visit> = {}): Visit {
+    return {
+      id: 'visit-1',
+      type: VisitType.PEDESTRIAN,
+      status: VisitStatus.PENDING,
+      visitorName: 'Ana Gómez',
+      validFrom: new Date('2026-07-12T10:00:00Z'),
+      validUntil: new Date('2026-07-12T20:00:00Z'),
+      vehicle: null,
+      ...overrides,
+    } as Visit;
+  }
+
+  beforeEach(() => {
+    familiesService = { findByDepartment: jest.fn() };
+    visitsService = { findAll: jest.fn() };
+    tool = new ConsultarVisitasTool(
+      familiesService as unknown as FamiliesService,
+      visitsService as unknown as VisitsService,
+    );
+  });
+
+  it('devuelve encontrado:false cuando no existe la familia/casa', async () => {
+    familiesService.findByDepartment.mockResolvedValue(null);
+
+    const result = await tool.execute(makeCtx(), { casa: '99' });
+
+    expect(result.encontrado).toBe(false);
+    expect(visitsService.findAll).not.toHaveBeenCalled();
+  });
+
+  it('lista las visitas activas/pendientes de la casa por defecto (soloActivas implícito)', async () => {
+    familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+    visitsService.findAll.mockResolvedValue([
+      makeVisit({ status: VisitStatus.PENDING }),
+      makeVisit({ id: 'visit-2', status: VisitStatus.COMPLETED }),
+      makeVisit({ id: 'visit-3', status: VisitStatus.ACTIVE }),
+    ]);
+
+    const result = await tool.execute(makeCtx(), { casa: '15' });
+
+    expect(visitsService.findAll).toHaveBeenCalledWith({
+      familyId: 'family-1',
+    });
+    expect(result.encontrado).toBe(true);
+    expect(result.cantidad).toBe(2);
+    expect(result.visitas?.map((v) => v.id)).toEqual(['visit-1', 'visit-3']);
+  });
+
+  it('con soloActivas:false devuelve TODAS las visitas, incluidas completadas/canceladas', async () => {
+    familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-A'));
+    visitsService.findAll.mockResolvedValue([
+      makeVisit({ status: VisitStatus.PENDING }),
+      makeVisit({ id: 'visit-2', status: VisitStatus.COMPLETED }),
+    ]);
+
+    const result = await tool.execute(makeCtx(), {
+      casa: '15',
+      soloActivas: false,
+    });
+
+    expect(result.cantidad).toBe(2);
+  });
+
+  describe('regresión cross-tenant (§6 del diseño)', () => {
+    it('NO alcanza visitas de una familia de otro condominio — responde "no encontrado"', async () => {
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-B'));
+
+      const result = await tool.execute(makeCtx({ tenantId: 'condo-A' }), {
+        casa: '15',
+      });
+
+      expect(result.encontrado).toBe(false);
+      expect(visitsService.findAll).not.toHaveBeenCalled();
+    });
+
+    it('un super-admin SÍ puede consultar visitas de cualquier condominio (bypass intencional)', async () => {
+      familiesService.findByDepartment.mockResolvedValue(makeFamily('condo-B'));
+      visitsService.findAll.mockResolvedValue([makeVisit()]);
+
+      const result = await tool.execute(
+        makeCtx({ tenantId: 'condo-A', isSuperAdmin: true }),
+        { casa: '15' },
+      );
+
+      expect(result.encontrado).toBe(true);
+      expect(visitsService.findAll).toHaveBeenCalledWith({
+        familyId: 'family-1',
+      });
+    });
+  });
+});

--- a/backend/src/agent/tools/consultar-visitas.tool.ts
+++ b/backend/src/agent/tools/consultar-visitas.tool.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { FamiliesService } from '../../families/families.service';
+import { VisitStatus } from '../../visits/entities/visit.entity';
+import { VisitsService } from '../../visits/visits.service';
+import type { AuthorizedContext } from '../types/authorized-context.type';
+import type { VigiliaTool } from '../types/vigilia-tool.type';
+
+const inputSchema = z.object({
+  casa: z
+    .string()
+    .min(1)
+    .describe(
+      'Número, código o nombre de casa/departamento tal como lo dijo el visitante (mismo formato que buscar_residente).',
+    ),
+  soloActivas: z
+    .boolean()
+    .optional()
+    .describe(
+      'Si es true (default), solo devuelve visitas pendientes o en curso — no completadas/canceladas/expiradas/rechazadas.',
+    ),
+});
+type ConsultarVisitasInput = z.infer<typeof inputSchema>;
+
+const visitaSchema = z.object({
+  id: z.string(),
+  visitante: z.string(),
+  tipo: z.string(),
+  estado: z.string(),
+  validoDesde: z.string(),
+  validoHasta: z.string(),
+  patente: z.string().nullable().optional(),
+});
+
+const outputSchema = z.object({
+  encontrado: z.boolean(),
+  mensaje: z.string().optional(),
+  casa: z.string().optional(),
+  cantidad: z.number().int().nonnegative().optional(),
+  visitas: z.array(visitaSchema).optional(),
+});
+type ConsultarVisitasOutput = z.infer<typeof outputSchema>;
+
+const ACTIVE_STATUSES = new Set<VisitStatus>([
+  VisitStatus.PENDING,
+  VisitStatus.ACTIVE,
+  VisitStatus.READY_FOR_REENTRY,
+]);
+
+/**
+ * Segunda `VigiliaTool` de consulta de Fase 2 (Bloque F2.1 —
+ * docs/modulos/agente-cerebro.md §12). `access: 'read'`.
+ *
+ * SEGURIDAD: en ESTA rama `VisitsService` aún NO es tenant-aware (el fix
+ * vive en el PR #50, no mergeado acá) — `findAll({ familyId })` no filtra por
+ * `organizationId`. Por eso el `familyId` que se le pasa NUNCA sale del
+ * input del modelo: se deriva EXCLUSIVAMENTE de `FamiliesService.findByDepartment`,
+ * que sí es tenant-scoped (misma garantía que ya documenta
+ * `BuscarResidenteTool` — su `findOne` interno aplica `scopeWhere` contra el
+ * tenant de la request). Además, se re-valida explícitamente
+ * `family.organizationId === ctx.tenantId` ANTES de listar sus visitas —
+ * defensa en profundidad ante un cambio futuro en `FamiliesService` (mismo
+ * criterio que el fix M1 de `NotificarResidenteTool`): un modelo nunca puede
+ * alcanzar visitas de otro condominio pasando un identificador de casa,
+ * porque nunca controla el `familyId` real usado en la consulta.
+ */
+@Injectable()
+export class ConsultarVisitasTool
+  implements VigiliaTool<ConsultarVisitasInput, ConsultarVisitasOutput>
+{
+  readonly name = 'consultar_visitas';
+  readonly description =
+    'Consulta las visitas (pendientes o en curso, salvo que se pida lo contrario) registradas para una casa/departamento. Requiere el número o código de casa.';
+  readonly inputSchema = inputSchema;
+  readonly outputSchema = outputSchema;
+  readonly access = 'read' as const;
+  readonly requiresApproval = false;
+  readonly requiredScopes = ['digital-concierge.access'];
+
+  constructor(
+    private readonly familiesService: FamiliesService,
+    private readonly visitsService: VisitsService,
+  ) {}
+
+  async execute(
+    ctx: AuthorizedContext,
+    input: ConsultarVisitasInput,
+  ): Promise<ConsultarVisitasOutput> {
+    const family = await this.familiesService.findByDepartment(input.casa);
+
+    if (
+      !family ||
+      (!ctx.isSuperAdmin && family.organizationId !== ctx.tenantId)
+    ) {
+      return {
+        encontrado: false,
+        mensaje: `No se encontró ninguna familia registrada en ${input.casa}.`,
+      };
+    }
+
+    const soloActivas = input.soloActivas ?? true;
+    const allVisits = await this.visitsService.findAll({ familyId: family.id });
+    const visits = soloActivas
+      ? allVisits.filter((visit) => ACTIVE_STATUSES.has(visit.status))
+      : allVisits;
+
+    return {
+      encontrado: true,
+      casa: input.casa,
+      cantidad: visits.length,
+      visitas: visits.map((visit) => ({
+        id: visit.id,
+        visitante: visit.visitorName,
+        tipo: visit.type,
+        estado: visit.status,
+        validoDesde: visit.validFrom.toISOString(),
+        validoHasta: visit.validUntil.toISOString(),
+        patente: visit.vehicle?.plate ?? null,
+      })),
+    };
+  }
+}

--- a/backend/src/agent/types/vigilia-tool.type.ts
+++ b/backend/src/agent/types/vigilia-tool.type.ts
@@ -32,12 +32,23 @@ export interface VigiliaTool<TInput = unknown, TOutput = unknown> {
   readonly access: 'read' | 'write';
 
   /**
-   * Si `true`, ejecutar esta tool requiere aprobación humana explícita
-   * (política de autonomía, §6 del doc). En A2a ninguna tool la usa todavía
-   * (solo hay tools `read`) — el dispatcher deja el campo listo para cuando
-   * Fase 2 agregue writes sensibles (portón/puerta).
+   * Política de autonomía (§6 del doc). En A2a/F2.1 todas las tools usaban un
+   * `boolean` fijo. Fase 2, Bloque F2.2 (docs/modulos/agente-cerebro.md §12):
+   * se admite además una función — necesaria para tools como `abrir_acceso`,
+   * donde la necesidad de aprobación depende del INPUT/contexto de CADA
+   * llamada (¿el visitante de ESTA sesión tiene una visita pre-aprobada
+   * vigente?), no de la tool en abstracto. `true`/resuelve a `true` => se
+   * escala (ver `ToolDispatcherService.escalateForApproval`); `false`/resuelve
+   * a `false` => se ejecuta directo.
+   *
+   * Retrocompatible: las tools existentes (`buscar_residente`,
+   * `finalizar_llamada`, etc.) siguen declarando el `boolean` literal tal
+   * cual — `ToolDispatcherService` distingue el caso en runtime con
+   * `typeof tool.requiresApproval === 'function'`.
    */
-  readonly requiresApproval: boolean;
+  readonly requiresApproval:
+    | boolean
+    | ((ctx: AuthorizedContext, input: TInput) => boolean | Promise<boolean>);
 
   /** Permisos (nombres `module.action` de DEFAULT_PERMISSIONS) requeridos para ejecutar. */
   readonly requiredScopes: Permission[];

--- a/backend/src/detections/detections.service.ts
+++ b/backend/src/detections/detections.service.ts
@@ -14,6 +14,8 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { UsersService } from '../users/users.service';
 import { NotificationType, NotificationPriority } from '../notifications/entities/notification.entity';
 import { HubGateway } from '../hub/hub.gateway';
+import { applyTenantFilter } from '../common/tenant/tenant-context.util';
+import type { TenantContext } from '../common/tenant/tenant-context.types';
 
 @Injectable()
 export class DetectionsService {
@@ -275,12 +277,29 @@ export class DetectionsService {
     return this.attemptsRepo.save(att);
   }
 
-  async listAttempts(limit = 50) {
-    return this.attemptsRepo.find({ 
-      relations: ['detection', 'residente', 'residente.family'], 
-      take: limit, 
-      order: { createdAt: 'DESC' } 
-    });
+  /**
+   * Fase 2, Bloque F2.1 (docs/modulos/agente-cerebro.md §12): `tenantScope`
+   * es OPCIONAL y ADITIVO — el caller existente (`DetectionsController`,
+   * gap conocido de tarea #19: "filtrado por tenant... queda PENDIENTE")
+   * sigue llamando sin este parámetro y mantiene su comportamiento actual
+   * (sin filtrar). La tool `consultar_accesos_recientes` es la primera en
+   * pasarlo, porque SÍ tiene un `AuthorizedContext` con tenant resuelto y NO
+   * puede confiar en el default sin filtro.
+   */
+  async listAttempts(limit = 50, tenantScope?: TenantContext) {
+    const query = this.attemptsRepo
+      .createQueryBuilder('attempt')
+      .leftJoinAndSelect('attempt.detection', 'detection')
+      .leftJoinAndSelect('attempt.residente', 'residente')
+      .leftJoinAndSelect('residente.family', 'family')
+      .orderBy('attempt.createdAt', 'DESC')
+      .take(limit);
+
+    if (tenantScope) {
+      applyTenantFilter(query, 'attempt', tenantScope);
+    }
+
+    return query.getMany();
   }
 
   /**

--- a/backend/src/migrations/1783890290995-CreatePendingActions.ts
+++ b/backend/src/migrations/1783890290995-CreatePendingActions.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Fase 2, Bloque F2.1 (docs/modulos/agente-cerebro.md §12): tabla del
+ * mecanismo de autonomía/aprobación del agente-cerebro. `VigiliaTool.requiresApproval`
+ * existía en el contrato desde Fase 1 (§5 del diseño) pero no tenía dónde
+ * persistir una acción escalada — este bloque activa esa política.
+ *
+ * Mismo criterio que el resto de columnas `organizationId`/`tenantId` de
+ * Fase 0/1 (uuid nullable + índice, sin FK — ver docstring de
+ * AddOrganizationIdToConciergeSessions): nullable porque una acción puede
+ * escalar desde un contexto sin condominio resuelto (hub aún no asociado).
+ */
+export class CreatePendingActions1783890290995 implements MigrationInterface {
+  name = 'CreatePendingActions1783890290995';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "pending_actions_status_enum" AS ENUM ('pending', 'approved', 'rejected', 'executed');
+      EXCEPTION
+        WHEN duplicate_object THEN null;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "pending_actions" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "tenantId" uuid,
+        "sessionId" uuid,
+        "toolName" character varying(128) NOT NULL,
+        "input" jsonb NOT NULL,
+        "requestId" character varying(64) NOT NULL,
+        "status" "pending_actions_status_enum" NOT NULL DEFAULT 'pending',
+        "contextSnapshot" jsonb,
+        "result" jsonb,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "resolvedBy" uuid,
+        "resolvedAt" timestamptz,
+        CONSTRAINT "PK_pending_actions_id" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_pending_actions_tenant_id"
+      ON "pending_actions" ("tenantId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_pending_actions_session_id"
+      ON "pending_actions" ("sessionId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_pending_actions_status"
+      ON "pending_actions" ("status")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_pending_actions_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_pending_actions_session_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_pending_actions_tenant_id"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "pending_actions"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "pending_actions_status_enum"`);
+  }
+}

--- a/backend/src/migrations/1783900000000-AddFailedExpiredToPendingActions.ts
+++ b/backend/src/migrations/1783900000000-AddFailedExpiredToPendingActions.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Fase 2 (revisión pre-F2.2): agrega los estados `failed`/`expired` al
+ * mecanismo de autonomía/aprobación (ver
+ * `PendingActionStatus`/`PendingActionsService.approve`) y la columna
+ * `lastError` para guardar el motivo. Complementa
+ * `CreatePendingActions1783890290995` en vez de reescribirla — el enum ya
+ * tiene filas en `pending`/`approved`/`rejected`/`executed` en cualquier
+ * ambiente donde este bloque ya corrió.
+ *
+ * `ALTER TYPE ... ADD VALUE` no puede ejecutarse dentro de una transacción en
+ * versiones viejas de Postgres — se envuelve en el mismo patrón
+ * `DO $$ ... EXCEPTION duplicate_object` que ya usa la migración anterior
+ * para que sea re-ejecutable sin romper si el valor ya existe (Postgres 12+
+ * soporta `ADD VALUE IF NOT EXISTS` directo, que es lo que se usa acá).
+ */
+export class AddFailedExpiredToPendingActions1783900000000
+  implements MigrationInterface
+{
+  name = 'AddFailedExpiredToPendingActions1783900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "pending_actions_status_enum" ADD VALUE IF NOT EXISTS 'failed'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "pending_actions_status_enum" ADD VALUE IF NOT EXISTS 'expired'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pending_actions" ADD COLUMN IF NOT EXISTS "lastError" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Postgres no soporta remover valores de un enum sin recrear el tipo
+    // (requeriría reescribir la tabla y cualquier fila que ya use
+    // 'failed'/'expired'). Se deja como limitación documentada — el down()
+    // revierte lo que SÍ es seguro revertir (la columna).
+    await queryRunner.query(
+      `ALTER TABLE "pending_actions" DROP COLUMN IF EXISTS "lastError"`,
+    );
+  }
+}

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -468,6 +468,74 @@ export class NotificationsService {
   }
 
   /**
+   * Igual que `notifyByRole` pero acotado a los usuarios con el rol dado que
+   * pertenecen a `organizationId` (Fase 2, revisión pre-F2.2 —
+   * docs/modulos/agente-cerebro.md §12: fix del leak de escalamiento
+   * cross-tenant en `PendingActionsService.notifyEscalation`/
+   * `notifyResolution`, que notificaba a conserjes de TODOS los condominios).
+   *
+   * `UsersService.findByRole` no filtra por tenant porque NO EXISTE una
+   * columna `organizationId` a nivel de `User` ni de `Role` en el esquema
+   * actual (`Role.name` es único global; `User.family` es nulo para staff
+   * sin residencia asignada) — no hay JOIN posible ahí. El filtrado ocurre
+   * acá resolviendo la organización REAL de cada candidato con el mismo
+   * mecanismo canónico que ya usa `create()` arriba
+   * (`resolveOrganizationIdForUser` contra la tabla `member` de better-auth,
+   * la única fuente de verdad de membresía de organización del sistema).
+   *
+   * `organizationId: null` (el "cajón sin condominio" ya usado en el resto
+   * del sistema — hub aún no asociado) hace match por IGUALDAD, no por
+   * bypass: solo notifica a usuarios cuya organización resuelta sea también
+   * `null`, nunca a todos.
+   */
+  async notifyByRoleForOrganization(
+    roleName: string,
+    organizationId: string | null,
+    type: NotificationType,
+    title: string,
+    message: string,
+    options?: {
+      priority?: NotificationPriority;
+      data?: any;
+      requiresAction?: boolean;
+    },
+  ): Promise<Notification[]> {
+    const candidates = await this.usersService.findByRole(roleName);
+
+    const scoped: typeof candidates = [];
+    for (const user of candidates) {
+      const userOrganizationId = await resolveOrganizationIdForUser(
+        user.id,
+        this.dataSource,
+      );
+      if (userOrganizationId === organizationId) {
+        scoped.push(user);
+      }
+    }
+
+    this.logger.log(
+      `Notificando a ${scoped.length}/${candidates.length} usuarios con rol ${roleName} (organizationId=${organizationId ?? 'null'})`,
+    );
+
+    const notifications: Notification[] = [];
+
+    for (const user of scoped) {
+      const notification = await this.create({
+        recipientId: user.id,
+        type,
+        title,
+        message,
+        priority: options?.priority || NotificationPriority.NORMAL,
+        data: options?.data,
+        requiresAction: options?.requiresAction,
+      });
+      notifications.push(notification);
+    }
+
+    return notifications;
+  }
+
+  /**
    * Notificar a múltiples usuarios con el mismo mensaje
    */
   async notifyMultiple(

--- a/docs/modulos/agente-cerebro.md
+++ b/docs/modulos/agente-cerebro.md
@@ -154,3 +154,36 @@ Se documenta y ejecuta por módulo. Orden sugerido:
 **Aún por confirmar:**
 - **`X-Hub-Secret` a medio camino:** ¿fue olvido o intención? Definir el mecanismo de auth de los clientes-transporte (hub por secret; web por sesión de usuario).
 - **Política de autonomía por acción**: ¿qué puede hacer el agente solo (abrir a un residente identificado) vs. qué escala a humano? Probablemente **configurable por condominio**.
+
+## 12. Fase 2 — diseño
+
+### 12.1 Decisiones tomadas (Benjamin)
+
+- **Apertura física autónoma con reglas**: el agente puede abrir el portón/puerta **solo** cuando el visitante queda identificado con certeza (residente reconocido, visita pre-aprobada válida) — cualquier caso dudoso **escala** al residente/conserje humano en vez de decidir. El criterio "autónomo vs. escala" se implementa **por-tool** (F2.2, `abrir_porton`), no acá — F2.1 deja listo el **mecanismo genérico** que ese criterio va a usar.
+- **"Llamar a residencia" = solo notificar**: no se agrega un canal de voz nuevo cliente↔residente. "Llamar" en el vocabulario del citófono se traduce a notificación (push/WS) al residente — ya existe (`notificar_residente`, Fase 1) y se reusa, no se reinventa.
+- **Voz realtime (D2)** ya se logró en F1 (el core del agente vive en el backend; el transporte de audio sigue siendo delgado en los clientes) — F2 solo consolida ese transporte, no es un rediseño.
+- **Arranque de F2** = tools de consulta (read, sin riesgo) **+** activar el mecanismo de autonomía que el contrato `VigiliaTool.requiresApproval` prometía desde Fase 1 pero que ningún consumidor leía todavía.
+
+### 12.2 Secuencia F2.1 → F2.4
+
+1. **F2.1 (este bloque)**: 3 tools de consulta (`consultar_vehiculo`, `consultar_visitas`, `consultar_accesos_recientes`) + mecanismo de autonomía/aprobación genérico (`PendingAction` + escalamiento + aprobación idempotente) — sin ninguna tool todavía usando `requiresApproval: true` en producción.
+2. **F2.2**: `abrir_porton`/`abrir_puerta` con el criterio "autónomo vs. escala" real (residente identificado/visita pre-aprobada → autónomo; dudoso → `requiresApproval: true`, usa el mecanismo de F2.1).
+3. **F2.3**: orquestación event-driven (patente LPR / citófono / anomalía → decisión del agente) sobre el catálogo ya expandido.
+4. **F2.4**: consolidación del transporte de voz realtime (RPi como puente delgado) + cierre de Fase 2.
+
+### 12.3 Mecanismo de autonomía — diseño
+
+**Problema que resuelve**: desde Fase 1, `VigiliaTool.requiresApproval` (§5) existía en el contrato pero `ToolDispatcherService` lo ignoraba — toda tool se ejecutaba directo. F2.1 activa ese campo.
+
+**Piezas:**
+
+- **`PendingAction`** (`backend/src/agent/entities/pending-action.entity.ts`, migración `1783890290995-CreatePendingActions.ts`): `tenantId`/`sessionId` (nullable, mismo "cajón sin condominio" que el resto del sistema), `toolName`, `input` (ya validado por Zod, no el `rawInput` del modelo), `requestId` (correlación de auditoría), `status` (`pending` → `approved` → `executed`, o `rejected` como terminal alternativo), `contextSnapshot` (el `AuthorizedContext` completo que autorizó la escalada — necesario para poder re-invocar `tool.execute()` con fidelidad en un turno HTTP distinto, el de la aprobación), `result` (salida ya validada por `outputSchema`, para servirla sin re-ejecutar), `resolvedBy`/`resolvedAt`.
+- **`ToolDispatcherService.execute`** (`tool-dispatcher.service.ts`): scopes → Zod-in (sin cambios) → **si `tool.requiresApproval`**, delega en `PendingActionsService.create` (crea + notifica) y devuelve el envelope fijo `{ pendiente: true, pendingActionId, mensaje }` (NO se valida contra `tool.outputSchema`, que describe la tool ya ejecutada) → si no, ejecuta directo como en Fase 1. Ambos caminos auditan con la MISMA función (`tool-audit.util.ts`, extraída de la lógica que antes vivía solo en el dispatcher) — regla dura #4 del §5 se mantiene en los dos caminos.
+- **Escalamiento**: `PendingActionsService.notifyEscalation` usa `NotificationsService.notifyByRole('Conserje', ...)` con `requiresAction: true` — mismo patrón que ya usa `DetectionsService.createPendingDetectionForConcierge` para detecciones pendientes de aprobación.
+- **Endpoint de aprobación** (`PendingActionsController`, `POST /concierge/pending-actions/:id/{approve,reject}`): `AuthGuard` (sesión humana, NO hub — un hub escala, un humano decide) + `RequirePermissions('digital-concierge.manage')`. Verifica tenant vía `PendingActionsService.findForTenant` (mismo patrón `findSessionForTenant` de `DigitalConciergeService`).
+- **Idempotencia de la ejecución**: NO se basa en comparar `requestId`, sino en una actualización atómica condicionada (`repo.update({ id, status: Not('executed') }, ...)`): si dos aprobaciones llegan concurrentes, solo una transiciona el estado y ejecuta la tool; la otra observa `affected === 0`, relee el estado final (`executed`) y devuelve el `result` ya calculado sin volver a invocar `tool.execute`.
+
+### 12.4 Deuda conocida (heredada, no introducida por F2.1)
+
+- `NotificationsService.notifyByRole`/`UsersService.findByRole` no filtran por tenant — la notificación de escalamiento llega a conserjes de **todos** los condominios, no solo el de la `PendingAction`. Mismo gap que ya tenía `DetectionsService.createPendingDetectionForConcierge` (no es una regresión de este bloque).
+- `Visit.organizationId` existe en el schema pero `VisitsService` no lo estampa ni lo filtra todavía (fix vive en el PR #50) — `consultar_visitas` deriva el tenant exclusivamente desde `FamiliesService` (sí tenant-scoped), nunca confía en la columna de `Visit`.


### PR DESCRIPTION
## Fase 2 (núcleo) — Agente completo: tools + autonomía

> **Stacked sobre Fase 1 (#49)** — la base es `feature/fase-1-agente-cerebro`. Al mergear #49, este PR queda contra `main` con solo su diff.

Amplía el agente-cerebro con el catálogo de acciones y el mecanismo de autonomía. La voz realtime ya estaba resuelta en F1 (patrón cliente-delgado), así que F2 se centró en tools + política de autonomía.

### Qué incluye
- **Tools de consulta** (`consultar_vehiculo`, `consultar_visitas`, `consultar_accesos_recientes`), todas re-scopeadas por tenant en la tool (Vehicles/Visits no son tenant-aware en esta rama).
- **Mecanismo de autonomía**: `PendingAction` + migraciones. El dispatcher ahora **lee `requiresApproval`** (antes muerto) → crea la acción pendiente, **escala al conserje del tenant** y no ejecuta; endpoint de aprobación **idempotente** (claim solo desde `PENDING`/`FAILED`), con estado `FAILED`+retry y `EXPIRED`, y **re-validación de sesión activa** antes de ejecutar diferido.
- **`requiresApproval` dinámico** (`boolean | (ctx,input)=>boolean`) evaluado server-side por el dispatcher.
- **Tool `abrir_acceso`** (portón/puerta): apertura autónoma **solo con identidad verificada** (patente LPR / QR que matchee una visita pre-aprobada); todo lo declarado por voz **escala** (fail-closed). Emisión dirigida por hub/organización, tenant-scoped.

### Seguridad (dos hallazgos críticos encontrados y corregidos en revisión)
1. **Race condition** en la aprobación: el claim `status != EXECUTED` no excluía `APPROVED` → dos aprobaciones concurrentes abrían el portón dos veces. Corregido (claim desde `PENDING`, serializado por row-lock) + test de concurrencia real.
2. **Autorización por casa, no por persona**: la apertura autónoma concedía si la casa (atacante-controlada) tenía *cualquier* visita vigente, sin comparar identidad. Corregido: exige identidad **verificada** que matchee la visita.

### Verificación
- Build limpio; **82 tests del módulo agent verdes**, incluidos los tests que reproducen ambos ataques (ahora escalan / no abren) y regresiones cross-tenant.

### Deuda conocida (seguimiento)
- **No existe vínculo identidad-verificada ↔ `ConciergeSession`** hoy → la apertura por citófono **siempre escala** (seguro e intencional). Cablear LPR/QR a la sesión es la extensión que habilita la autonomía real — y **debe re-auditarse** ese punto cuando se haga (solo poblarse desde canales verificados, nunca desde datos de voz).
- Tras aprobar una apertura escalada, **no se avisa en vivo** al visitante en la llamada (no hay canal de vuelta para esta tool).
- `DetectionsService.createPendingDetectionForConcierge` mantiene el mismo leak de notificación cross-tenant que ya se corrigió en el escalamiento del agente (follow-up).
- Pendiente de F2 (no incluido aquí): orquestación event-driven (patente desconocida/anomalía → agente) y más tools write (gestionar visitas, reportes).
