### PR TITLE
chore: limpieza de duplicaciones del agente + hardening menor

### DIFF
--- a/backend/src/agent/pending-actions.service.spec.ts
+++ b/backend/src/agent/pending-actions.service.spec.ts
@@ -84,7 +84,10 @@ describe('PendingActionsService', () => {
     Pick<DigitalConciergeService, 'findSessionForTenant'>
   >;
   let hubGateway: jest.Mocked<
-    Pick<HubGateway, 'isHubConnected' | 'sendToHub' | 'sendToOrganization'>
+    Pick<
+      HubGateway,
+      'isHubConnected' | 'sendToHub' | 'sendToOrganization' | 'sendToSession'
+    >
   >;
   let idCounter: number;
 
@@ -176,6 +179,24 @@ describe('PendingActionsService', () => {
       isHubConnected: jest.fn().mockReturnValue(false),
       sendToHub: jest.fn().mockReturnValue(true),
       sendToOrganization: jest.fn(),
+      // Réplica fiel de `HubGateway.sendToSession` real (limpieza post-
+      // auditoría, dedup DUP1): delega en los mocks de arriba en vez de
+      // mockearse por separado, así las aserciones existentes sobre
+      // `sendToHub`/`sendToOrganization` siguen validando el mismo criterio
+      // (hub propio conectado vs. broadcast por organización) sin cambios.
+      sendToSession: jest.fn(
+        (
+          session: { hubId: string | null; organizationId: string | null },
+          event: string,
+          data: unknown,
+        ) => {
+          if (session.hubId && hubGateway.isHubConnected(session.hubId)) {
+            hubGateway.sendToHub(session.hubId, event, data);
+            return;
+          }
+          hubGateway.sendToOrganization(session.organizationId, event, data);
+        },
+      ),
     };
 
     service = new PendingActionsService(

--- a/backend/src/agent/pending-actions.service.ts
+++ b/backend/src/agent/pending-actions.service.ts
@@ -27,12 +27,7 @@ import { ToolRegistryService } from './tool-registry.service';
 import { auditToolCall, describeToolError } from './tool-audit.util';
 import type { AuthorizedContext } from './types/authorized-context.type';
 import type { VigiliaTool } from './types/vigilia-tool.type';
-
-/** Forma mínima que necesita `findForTenant` — igual criterio que `TenantScope` en digital-concierge.service.ts. */
-export interface TenantScope {
-  tenantId: string | null;
-  isSuperAdmin: boolean;
-}
+import type { TenantScope } from '../common/tenant/tenant-context.types';
 
 /**
  * Fase 2, Bloque F2.1 (docs/modulos/agente-cerebro.md §12): mecanismo de
@@ -582,15 +577,7 @@ export class PendingActionsService {
         timestamp: new Date(),
       };
 
-      if (session.hubId && this.hubGateway.isHubConnected(session.hubId)) {
-        this.hubGateway.sendToHub(session.hubId, event, payload);
-      } else {
-        this.hubGateway.sendToOrganization(
-          session.organizationId,
-          event,
-          payload,
-        );
-      }
+      this.hubGateway.sendToSession(session, event, payload);
     } catch (error) {
       // No terminal: la sesión pudo cerrarse entre la escalada y la
       // aprobación (`findSessionForTenant` lanza `NotFoundException`/

--- a/backend/src/agent/tools/abrir-acceso.tool.spec.ts
+++ b/backend/src/agent/tools/abrir-acceso.tool.spec.ts
@@ -39,7 +39,10 @@ describe('AbrirAccesoTool', () => {
   let familiesService: jest.Mocked<Pick<FamiliesService, 'findByDepartment'>>;
   let visitsService: jest.Mocked<Pick<VisitsService, 'findAll'>>;
   let hubGateway: jest.Mocked<
-    Pick<HubGateway, 'isHubConnected' | 'sendToHub' | 'sendToOrganization'>
+    Pick<
+      HubGateway,
+      'isHubConnected' | 'sendToHub' | 'sendToOrganization' | 'sendToSession'
+    >
   >;
 
   const NOW = new Date('2026-07-12T12:00:00Z');
@@ -142,6 +145,24 @@ describe('AbrirAccesoTool', () => {
       isHubConnected: jest.fn().mockReturnValue(false),
       sendToHub: jest.fn().mockReturnValue(true),
       sendToOrganization: jest.fn(),
+      // Réplica fiel de `HubGateway.sendToSession` real (limpieza post-
+      // auditoría, dedup DUP1): delega en los mocks de arriba en vez de
+      // mockearse por separado, así las aserciones existentes sobre
+      // `sendToHub`/`sendToOrganization` siguen validando el mismo criterio
+      // (hub propio conectado vs. broadcast por organización) sin cambios.
+      sendToSession: jest.fn(
+        (
+          session: { hubId: string | null; organizationId: string | null },
+          event: string,
+          data: unknown,
+        ) => {
+          if (session.hubId && hubGateway.isHubConnected(session.hubId)) {
+            hubGateway.sendToHub(session.hubId, event, data);
+            return;
+          }
+          hubGateway.sendToOrganization(session.organizationId, event, data);
+        },
+      ),
     };
 
     tool = new AbrirAccesoTool(

--- a/backend/src/agent/tools/abrir-acceso.tool.ts
+++ b/backend/src/agent/tools/abrir-acceso.tool.ts
@@ -4,7 +4,7 @@ import { FamiliesService } from '../../families/families.service';
 import { DigitalConciergeService } from '../../digital-concierge/services/digital-concierge.service';
 import type { ConciergeSession } from '../../digital-concierge/entities/concierge-session.entity';
 import { HubGateway } from '../../hub/hub.gateway';
-import { VisitStatus } from '../../visits/entities/visit.entity';
+import { NON_TERMINAL_VISIT_STATUSES } from '../../visits/visits.constants';
 import { VisitsService } from '../../visits/visits.service';
 import type { AuthorizedContext } from '../types/authorized-context.type';
 import type { VigiliaTool } from '../types/vigilia-tool.type';
@@ -23,23 +23,6 @@ const outputSchema = z.object({
   mensaje: z.string(),
 });
 type AbrirAccesoOutput = z.infer<typeof outputSchema>;
-
-/**
- * Estados de `Visit` que cuentan como "acceso autorizado" para la política de
- * autonomía de abajo — MISMO set que `ACTIVE_STATUSES` de
- * `ConsultarVisitasTool` (docs/modulos/agente-cerebro.md §12): una visita
- * `PENDING` (el residente ya la pre-registró, el visitante aún no marca
- * entrada), `ACTIVE` (ya en curso) o `READY_FOR_REENTRY` (puede reingresar) es
- * "visita pre-aprobada" a efectos de abrir el acceso sin escalar. No se
- * extrae a un util compartido para no acoplar dos tools que hoy evolucionan
- * independiente — si un tercer consumidor necesita el mismo criterio, vale la
- * pena centralizarlo entonces (ver "deuda" en el reporte de la tarea).
- */
-const PRE_APPROVED_VISIT_STATUSES = new Set<VisitStatus>([
-  VisitStatus.PENDING,
-  VisitStatus.ACTIVE,
-  VisitStatus.READY_FOR_REENTRY,
-]);
 
 /**
  * CORRECCIÓN CRÍTICA (auditoría de seguridad, hallazgo F2.2 — "autoriza por
@@ -214,15 +197,7 @@ export class AbrirAccesoTool
       visitId: session.createdVisit?.id ?? null,
     };
 
-    if (session.hubId && this.hubGateway.isHubConnected(session.hubId)) {
-      this.hubGateway.sendToHub(session.hubId, hubEvent, payload);
-    } else {
-      this.hubGateway.sendToOrganization(
-        session.organizationId,
-        hubEvent,
-        payload,
-      );
-    }
+    this.hubGateway.sendToSession(session, hubEvent, payload);
 
     return {
       abierto: true,
@@ -303,7 +278,7 @@ export class AbrirAccesoTool
     const now = new Date();
 
     return visits.some((visit) => {
-      if (!PRE_APPROVED_VISIT_STATUSES.has(visit.status)) {
+      if (!NON_TERMINAL_VISIT_STATUSES.has(visit.status)) {
         return false;
       }
       if (!(visit.validFrom <= now && visit.validUntil >= now)) {

--- a/backend/src/agent/tools/consultar-visitas.tool.ts
+++ b/backend/src/agent/tools/consultar-visitas.tool.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 import { FamiliesService } from '../../families/families.service';
-import { VisitStatus } from '../../visits/entities/visit.entity';
+import { NON_TERMINAL_VISIT_STATUSES } from '../../visits/visits.constants';
 import { VisitsService } from '../../visits/visits.service';
 import type { AuthorizedContext } from '../types/authorized-context.type';
 import type { VigiliaTool } from '../types/vigilia-tool.type';
@@ -41,25 +41,19 @@ const outputSchema = z.object({
 });
 type ConsultarVisitasOutput = z.infer<typeof outputSchema>;
 
-const ACTIVE_STATUSES = new Set<VisitStatus>([
-  VisitStatus.PENDING,
-  VisitStatus.ACTIVE,
-  VisitStatus.READY_FOR_REENTRY,
-]);
-
 /**
  * Segunda `VigiliaTool` de consulta de Fase 2 (Bloque F2.1 —
  * docs/modulos/agente-cerebro.md §12). `access: 'read'`.
  *
- * SEGURIDAD: en ESTA rama `VisitsService` aún NO es tenant-aware (el fix
- * vive en el PR #50, no mergeado acá) — `findAll({ familyId })` no filtra por
- * `organizationId`. Por eso el `familyId` que se le pasa NUNCA sale del
- * input del modelo: se deriva EXCLUSIVAMENTE de `FamiliesService.findByDepartment`,
- * que sí es tenant-scoped (misma garantía que ya documenta
- * `BuscarResidenteTool` — su `findOne` interno aplica `scopeWhere` contra el
- * tenant de la request). Además, se re-valida explícitamente
- * `family.organizationId === ctx.tenantId` ANTES de listar sus visitas —
- * defensa en profundidad ante un cambio futuro en `FamiliesService` (mismo
+ * SEGURIDAD: `VisitsService` ya es tenant-aware (PR #50, en main) —
+ * `findAll({ familyId })` filtra por `organizationId` vía `TenantContextService`
+ * salvo que se pase `skipTenantScope`, que esta tool nunca pasa. Aun así, el
+ * `familyId` que se le pasa NUNCA sale del input del modelo: se deriva
+ * EXCLUSIVAMENTE de `FamiliesService.findByDepartment`, que también es
+ * tenant-scoped (misma garantía que ya documenta `BuscarResidenteTool` — su
+ * `findOne` interno aplica `scopeWhere` contra el tenant de la request).
+ * Además, se re-valida explícitamente `family.organizationId === ctx.tenantId`
+ * ANTES de listar sus visitas — defensa en profundidad por capas (mismo
  * criterio que el fix M1 de `NotificarResidenteTool`): un modelo nunca puede
  * alcanzar visitas de otro condominio pasando un identificador de casa,
  * porque nunca controla el `familyId` real usado en la consulta.
@@ -101,7 +95,7 @@ export class ConsultarVisitasTool
     const soloActivas = input.soloActivas ?? true;
     const allVisits = await this.visitsService.findAll({ familyId: family.id });
     const visits = soloActivas
-      ? allVisits.filter((visit) => ACTIVE_STATUSES.has(visit.status))
+      ? allVisits.filter((visit) => NON_TERMINAL_VISIT_STATUSES.has(visit.status))
       : allVisits;
 
     return {

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -81,9 +81,19 @@ const logger = new Logger('AuthModule');
     // importa `ThrottlerModule` directamente) pueda usar `ThrottlerGuard` +
     // `@Throttle({ 'concierge-agent-chat': {...} })` en su controller, mismo
     // patrón que 'login' en AuthController.
+    //
+    // 'concierge-execute-tool' (limpieza post-auditoría, MENOR 2): mismo
+    // criterio que 'concierge-agent-chat' — `POST
+    // /concierge/session/:id/execute-tool` (DigitalConciergeController) es el
+    // canal de producción real (Realtime voice: frontend/vigilia-hub) y no
+    // tenía ningún límite de tasa, a diferencia de `/concierge/agent/chat`.
+    // Límite más alto que el de chat (60 vs 20 por minuto) porque una sola
+    // llamada por citófono puede disparar varias tools (buscar_residente,
+    // guardar_datos_visitante x N, abrir_acceso, etc.) en la misma ventana.
     ThrottlerModule.forRoot([
       { name: 'login', ttl: 60_000, limit: 5 },
       { name: 'concierge-agent-chat', ttl: 60_000, limit: 20 },
+      { name: 'concierge-execute-tool', ttl: 60_000, limit: 60 },
     ]),
     MailerModule.forRootAsync({
       imports: [ConfigModule],

--- a/backend/src/common/tenant/tenant-context.types.ts
+++ b/backend/src/common/tenant/tenant-context.types.ts
@@ -32,3 +32,22 @@ export const EMPTY_TENANT_CONTEXT: TenantContext = {
   organizationId: null,
   isSuperAdmin: false,
 };
+
+/**
+ * Forma mínima que necesitan `DigitalConciergeService.findSessionForTenant` y
+ * `PendingActionsService.findForTenant`/`approve`/`reject` para revalidar
+ * tenant (limpieza post-auditoría, dedup DUP3 — antes vivía duplicada como
+ * interface local en ambos servicios).
+ *
+ * Usa el vocabulario del agente-cerebro (`tenantId`, NO `organizationId`) a
+ * propósito — mismo valor que `TenantContext.organizationId` pero con nombre
+ * distinto en este subsistema (ver docstring de
+ * `PendingActionsController.resolveTenantScope`, que traduce entre ambos
+ * vocabularios en el borde del controller). Cualquier objeto con estos dos
+ * campos (incluido un `AuthorizedContext` completo) es asignable acá por
+ * tipado estructural.
+ */
+export interface TenantScope {
+  tenantId: string | null;
+  isSuperAdmin: boolean;
+}

--- a/backend/src/digital-concierge/digital-concierge.controller.ts
+++ b/backend/src/digital-concierge/digital-concierge.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Body, Param, Logger, UseGuards, Req } from '@nestjs/common';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import type { Request } from 'express';
 import {
   AuthorizedContextFactory,
@@ -124,8 +125,16 @@ export class DigitalConciergeController {
    * de validación Zod, o de negocio se traduce a `{ success: false, error }`
    * en vez de propagar un 4xx/5xx crudo — mismo comportamiento observable
    * que tenía el `switch` legacy.
+   *
+   * Limpieza post-auditoría (MENOR 2): este es el canal de producción real
+   * (Realtime voice vía frontend/vigilia-hub) y no tenía ningún límite de
+   * tasa, a diferencia de `/concierge/agent/chat` — throttler dedicado
+   * 'concierge-execute-tool' (registrado en auth.module.ts junto a
+   * 'concierge-agent-chat'/'login'; `ThrottlerModule` es `@Global()`).
    */
   @Post('session/:sessionId/execute-tool')
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ 'concierge-execute-tool': { limit: 60, ttl: 60_000 } })
   async executeTool(
     @Param('sessionId') sessionId: string,
     @Body() dto: ExecuteToolDto,

--- a/backend/src/digital-concierge/services/digital-concierge.service.ts
+++ b/backend/src/digital-concierge/services/digital-concierge.service.ts
@@ -14,6 +14,7 @@ import { SmsService } from '../../common/services/sms.service';
 import { QRCodeService } from '../../common/services/qrcode.service';
 import { HubGateway } from '../../hub/hub.gateway';
 import { User } from '../../users/entities/user.entity';
+import type { TenantScope } from '../../common/tenant/tenant-context.types';
 import {
   formatRut,
   isValidChileanPhone,
@@ -81,18 +82,13 @@ export interface SaveVisitorDataResult {
 }
 
 /**
- * Forma mínima de `AuthorizedContext` que este servicio necesita para el fix
- * M1 (defensa en profundidad, Bloque A2b — ver docstring de `notifyResident`
- * más abajo). Se define localmente en vez de importar `AuthorizedContext` de
- * `agent/types/` para no crear una dependencia de tipos del dominio hacia la
- * capa de agente (la dirección natural es agente → dominio, no al revés) —
- * cualquier objeto con estos dos campos (incluido un `AuthorizedContext`
- * completo) es asignable acá por tipado estructural.
+ * Re-exportado para no romper a los consumidores que ya importaban
+ * `TenantScope` desde este módulo (p.ej. specs de tools) — limpieza post-
+ * auditoría (dedup DUP3): la interface ahora vive en
+ * `common/tenant/tenant-context.types.ts`, compartida con
+ * `PendingActionsService`, en vez de declararse localmente acá.
  */
-export interface TenantScope {
-  tenantId: string | null;
-  isSuperAdmin: boolean;
-}
+export type { TenantScope };
 
 @Injectable()
 export class DigitalConciergeService {
@@ -479,12 +475,7 @@ export class DigitalConciergeService {
    * `null` — ver su docstring sobre el "cajón nulo").
    */
   private notifyHub(session: ConciergeSession, event: string, payload: unknown): void {
-    if (session.hubId && this.hubGateway.isHubConnected(session.hubId)) {
-      this.hubGateway.sendToHub(session.hubId, event, payload);
-      return;
-    }
-
-    this.hubGateway.sendToOrganization(session.organizationId, event, payload);
+    this.hubGateway.sendToSession(session, event, payload);
   }
 
   // ========== HERRAMIENTAS ==========
@@ -522,7 +513,13 @@ export class DigitalConciergeService {
     session: ConciergeSession,
     data: SaveVisitorDataInput,
   ): Promise<SaveVisitorDataResult> {
-    this.logger.debug('Saving visitor data...', data);
+    // No se loguea `data` — contiene PII del visitante en claro (nombre,
+    // rut, telefono, patente) y `main.ts` no fija `logLevels`, así que
+    // `debug` corre también en producción (hallazgo de limpieza post-
+    // auditoría, MENOR 1). `auditToolCall` (tool-audit.util.ts) sigue siendo
+    // la auditoría intencional que SÍ persiste estos campos en
+    // `system_logs` — esto es solo el log de diagnóstico, no se toca esa vía.
+    this.logger.debug('Saving visitor data...');
 
     let campoInvalido: SaveVisitorDataField | undefined;
     let mensajeInvalido: string | undefined;

--- a/backend/src/hub/hub.gateway.spec.ts
+++ b/backend/src/hub/hub.gateway.spec.ts
@@ -168,4 +168,72 @@ describe('HubGateway', () => {
       expect(delivered).toBe(0);
     });
   });
+
+  describe('sendToSession (limpieza post-auditoría, dedup DUP1)', () => {
+    /**
+     * Réplica del helper `connectHub` de arriba, en su propio describe para
+     * no acoplarse al estado de los tests de `sendToOrganization`.
+     */
+    async function connectHub(hubId: string, organizationId: string | null, secretHash: string, plaintextSecret: string) {
+      hubRepository.findOne.mockResolvedValueOnce(mockHub(hubId, organizationId, secretHash));
+      const socket = makeMockSocket(`sock-${hubId}`) as any;
+      await gateway.handleConnection({
+        ...socket,
+        handshake: { auth: { hubId, hubSecret: plaintextSecret } },
+      });
+      return socket;
+    }
+
+    it('dirige SOLO al hub propio de la sesión cuando está conectado (mismo criterio que tenía cada call-site duplicado)', async () => {
+      const socketOwn = await connectHub('hub-A', ORG_A, secretHashA, 'secret-hub-A');
+      const socketOther = await connectHub('hub-B', ORG_A, secretHashB, 'secret-hub-B');
+
+      gateway.sendToSession(
+        { hubId: 'hub-A', organizationId: ORG_A },
+        'hub:door_open',
+        { type: 'vehicular' },
+      );
+
+      expect(socketOwn.emit).toHaveBeenCalledWith('hub:door_open', { type: 'vehicular' });
+      expect(socketOther.emit).not.toHaveBeenCalledWith('hub:door_open', expect.anything());
+    });
+
+    it('cae a broadcast por organización cuando la sesión no tiene hubId asociado', async () => {
+      const socketA = await connectHub('hub-A', ORG_A, secretHashA, 'secret-hub-A');
+      const socketB = await connectHub('hub-B', ORG_B, secretHashB, 'secret-hub-B');
+
+      gateway.sendToSession(
+        { hubId: null, organizationId: ORG_A },
+        'hub:door_open',
+        { type: 'pedestrian' },
+      );
+
+      expect(socketA.emit).toHaveBeenCalledWith('hub:door_open', { type: 'pedestrian' });
+      expect(socketB.emit).not.toHaveBeenCalledWith('hub:door_open', expect.anything());
+    });
+
+    it('cae a broadcast por organización cuando el hubId de la sesión NO está conectado (p.ej. se cayó la conexión)', async () => {
+      const socketFallback = await connectHub('hub-A2', ORG_A, secretHashA, 'secret-hub-A');
+
+      gateway.sendToSession(
+        { hubId: 'hub-desconectado', organizationId: ORG_A },
+        'hub:door_open',
+        { type: 'vehicular' },
+      );
+
+      expect(socketFallback.emit).toHaveBeenCalledWith('hub:door_open', { type: 'vehicular' });
+    });
+
+    it('NUNCA hace broadcast global — sin organizationId y sin hub propio conectado, no entrega a nadie', async () => {
+      const socketA = await connectHub('hub-A', ORG_A, secretHashA, 'secret-hub-A');
+
+      gateway.sendToSession(
+        { hubId: null, organizationId: null },
+        'hub:door_open',
+        { type: 'vehicular' },
+      );
+
+      expect(socketA.emit).not.toHaveBeenCalledWith('hub:door_open', expect.anything());
+    });
+  });
 });

--- a/backend/src/hub/hub.gateway.ts
+++ b/backend/src/hub/hub.gateway.ts
@@ -253,6 +253,35 @@ export class HubGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   /**
+   * Limpieza post-auditoría (dedup DUP1): encapsula el patrón "hub propio
+   * conectado vs. broadcast por organización" que estaba triplicado en
+   * `DigitalConciergeService.notifyHub`, `AbrirAccesoTool.execute` y
+   * `PendingActionsService.notifyVisitorLive` — mismo criterio EXACTO en los
+   * tres call-sites originales: si `session.hubId` está seteado y ESE hub
+   * está conectado, se dirige SOLO a él (`sendToHub`); si no, se hace
+   * broadcast por organización (`sendToOrganization`, nunca broadcast global
+   * — ver su docstring sobre el "cajón nulo" cuando `organizationId` es
+   * `null`).
+   *
+   * Recibe solo los dos campos que necesita (no una `ConciergeSession`
+   * completa) para no acoplar `HubGateway` a esa entidad — cualquier objeto
+   * con esta forma (incluida una `ConciergeSession`) es asignable acá por
+   * tipado estructural.
+   */
+  sendToSession(
+    session: { hubId: string | null; organizationId: string | null },
+    event: string,
+    data: any,
+  ): void {
+    if (session.hubId && this.isHubConnected(session.hubId)) {
+      this.sendToHub(session.hubId, event, data);
+      return;
+    }
+
+    this.sendToOrganization(session.organizationId, event, data);
+  }
+
+  /**
    * Broadcast a todos los hubs conectados. OJO: NO usar para eventos que
    * disparen una acción física dirigida a UN condominio (p.ej. abrir
    * portón/puerta) — usar `sendToOrganization` en esos casos (hallazgo H2).

--- a/backend/src/visits/visits.constants.ts
+++ b/backend/src/visits/visits.constants.ts
@@ -1,0 +1,16 @@
+import { VisitStatus } from './entities/visit.entity';
+
+/**
+ * Limpieza post-auditoría (dedup DUP2): mismo `Set<VisitStatus>` que estaba
+ * duplicado en `agent/tools/abrir-acceso.tool.ts` (ahí como criterio de
+ * "visita pre-aprobada vigente" para la política de autonomía condicional) y
+ * en `agent/tools/consultar-visitas.tool.ts` (ahí como criterio de "visita
+ * activa" para el filtro por default) — ambos usan exactamente el mismo
+ * criterio subyacente: la visita NO llegó a un estado terminal (completed/
+ * cancelled/expired/denied).
+ */
+export const NON_TERMINAL_VISIT_STATUSES = new Set<VisitStatus>([
+  VisitStatus.PENDING,
+  VisitStatus.ACTIVE,
+  VisitStatus.READY_FOR_REENTRY,
+]);


### PR DESCRIPTION
Limpieza post-auditoria de arquitectura (PRs #49/#51/#52). Extrae HubGateway.sendToSession() eliminando el patron hub-propio-vs-broadcast triplicado; centraliza el Set de estados de visita (visits.constants) y la interface TenantScope (tenant-context.types). Menores: quita PII (rut/telefono/patente) del logger.debug de saveVisitorData; rate-limit en execute-tool; comentario stale corregido. 138 tests verdes, build limpio, sin cambio de comportamiento.